### PR TITLE
[BUGIFX] typo in logging warning

### DIFF
--- a/stable_pretraining/data/module.py
+++ b/stable_pretraining/data/module.py
@@ -52,14 +52,14 @@ class DataModule(pl.LightningDataModule):
             raise ValueError("They can't all be none")
         logging.info("Setting up DataModule")
         if train is None:
-            logging.warninging(
+            logging.warning(
                 "⚠️⚠️⚠️ train was not passed to DataModule, it is required"
                 "unless you only validate ⚠️⚠️⚠️"
             )
         self.train = self._format_data_conf(train, "train")
         self.test = self._format_data_conf(test, "test")
         if val is None:
-            logging.warninging(
+            logging.warning(
                 "⚠️⚠️⚠️ val was not passed to DataModule, it is required"
                 "unless you set `num_sanity_val_steps=0` and `val_check_interval=0` ⚠️⚠️⚠️"
             )


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->
This pull request fixes a minor typo in the `stable_pretraining/data/module.py` file, correcting the logging method name from `logging.warninging` to `logging.warning`. This change ensures that warning messages are properly logged during DataModule initialization.
<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
