### PR TITLE
[BUGFIX] seed_everything verbose

### DIFF
--- a/stable_pretraining/manager.py
+++ b/stable_pretraining/manager.py
@@ -275,7 +275,7 @@ class Manager(submitit.helpers.Checkpointable):
         #         signal.__dict__[self.slurm_requeue_signal], self.checkpoint_and_requeue
         #     )
         logging.info(f"🌱🌱🌱 SEEDING EVERYTHING with {self.seed=} 🌱🌱🌱")
-        pl.seed_everything(self.seed, workers=True, verbose=False)
+        pl.seed_everything(self.seed, workers=True)
         if isinstance(self.trainer, pl.Trainer):
             self._trainer = self.trainer
         else:


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->
This pull request makes a minor update to the seeding logic in `manager.py` by removing the `verbose=False` argument from the call to `pl.seed_everything`. 
<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
