### PR TITLE
[Cleanup] Reorganize dependencies into core and optional groups

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --user --upgrade --progress-bar off pip
       - name: Install 'stable_pretraining' package
         run: |
-          python -m pip install --user -e .[dev]
+          python -m pip install --user -e .[dev,vision,datasets]
       # Run Tests
       - name: Run Unit Tests
         run: pytest stable_pretraining/ -m unit --verbose --cov=stable_pretraining --cov-report term

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --user --upgrade --progress-bar off pip
       - name: Install 'stable_pretraining' package
         run: |
-          python -m pip install --user -e .[dev,vision,datasets]
+          python -m pip install --user -e .[all,dev]
       # Run Tests
       - name: Run Unit Tests
         run: pytest stable_pretraining/ -m unit --verbose --cov=stable_pretraining --cov-report term

--- a/README.md
+++ b/README.md
@@ -317,14 +317,14 @@ The library is not yet available on PyPI. You can install it from the source cod
     uv pip install torch torchvision torchaudio
     uv pip install -e .  # Core dependencies only
     ```
-    
+
     For optional features (vision models, experiment tracking, cluster support, etc.):
     ```bash
     uv pip install -e ".[vision,tracking]"  # Example: add vision models and wandb
     uv pip install -e ".[all]"  # Or install all optional dependencies
     ```
     See `pyproject.toml` for available dependency groups (`vision`, `tracking`, `cluster`, `visualization`, `datasets`, `extras`, `dev`, `doc`).
-    
+
     If you do not want to use uv, simply remove it from the above commands.
 
 3. API login (optional)

--- a/README.md
+++ b/README.md
@@ -312,12 +312,20 @@ The library is not yet available on PyPI. You can install it from the source cod
   </details>
 
 2. Pytorch and our library (we recommend using `uv` for quicker package management):
-    ```
+    ```bash
     pip3 install uv
     uv pip install torch torchvision torchaudio
-    uv pip install -e .
+    uv pip install -e .  # Core dependencies only
     ```
-    if you do not want to use uv, simply remove it from the above commands.
+    
+    For optional features (vision models, experiment tracking, cluster support, etc.):
+    ```bash
+    uv pip install -e ".[vision,tracking]"  # Example: add vision models and wandb
+    uv pip install -e ".[all]"  # Or install all optional dependencies
+    ```
+    See `pyproject.toml` for available dependency groups (`vision`, `tracking`, `cluster`, `visualization`, `datasets`, `extras`, `dev`, `doc`).
+    
+    If you do not want to use uv, simply remove it from the above commands.
 
 3. API login (optional)
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,25 +9,12 @@ authors = []
 license = {text = "MIT"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = [
+    # Core dependencies - minimal required for basic SSL training
     "torch",
     "torchvision",
-    "hydra-core",
     "lightning",
-    "hydra-submitit-launcher",
-    "submitit",
-    "wandb",
-    "datasets",
+    "hydra-core",
     "loguru",
-    "scikit-learn>=1.7.0",
-    "prettytable",
-    "timm",
-    "transformers",
-    "tabulate",
-    "matplotlib",
-    "requests-cache[all]",
-    "richuru",
-    "minari[hdf5]>=0.5.3",
-    "pillow>=11.3.0",
 ]
 
 dynamic = ["version"]
@@ -45,6 +32,50 @@ packages = ["stable_pretraining"]
 version = {attr = "stable_pretraining.__about__.__version__"}
 
 [project.optional-dependencies]
+# Advanced vision models and transforms
+vision = [
+    "timm",
+    "transformers",
+    "pillow>=11.3.0",
+]
+
+# Experiment tracking
+tracking = [
+    "wandb",
+]
+
+# Cluster/SLURM execution support
+cluster = [
+    "hydra-submitit-launcher",
+    "submitit",
+]
+
+# Visualization and reporting tools
+visualization = [
+    "matplotlib",
+    "prettytable",
+    "tabulate",
+]
+
+# Extra dataset support
+datasets = [
+    "datasets",  # HuggingFace datasets
+    "minari[hdf5]>=0.5.3",  # Reinforcement learning datasets
+]
+
+# Additional utilities
+extras = [
+    "scikit-learn>=1.7.0",  # sklearn model checkpointing
+    "requests-cache[all]",  # Caching for API requests
+    "richuru",  # Enhanced logging formatting
+]
+
+# All optional dependencies
+all = [
+    "stable-pretraining[vision,tracking,cluster,visualization,datasets,extras]",
+]
+
+# Development tools
 dev = [
     "pytest",
     "coverage",
@@ -54,6 +85,7 @@ dev = [
     "ruff",
 ]
 
+# Documentation tools
 doc = [
     "sphinx",
     "sphinx-gallery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     # Core dependencies - minimal required for basic SSL training
     "torch",
     "torchvision",
+    "torchmetrics",
     "lightning",
     "hydra-core",
     "loguru",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "lightning",
     "hydra-core",
     "loguru",
+    "tabulate",
 ]
 
 dynamic = ["version"]
@@ -55,7 +56,6 @@ cluster = [
 visualization = [
     "matplotlib",
     "prettytable",
-    "tabulate",
 ]
 
 # Extra dataset support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ visualization = [
 # Extra dataset support
 datasets = [
     "datasets",  # HuggingFace datasets
+    "pyarrow>=15.0.0",  # Required for datasets compatibility
     "minari[hdf5]>=0.5.3",  # Reinforcement learning datasets
 ]
 

--- a/stable_pretraining/__init__.py
+++ b/stable_pretraining/__init__.py
@@ -127,7 +127,8 @@ try:
     import datasets
 
     datasets.logging.set_verbosity_info()
-except ModuleNotFoundError:
+except (ModuleNotFoundError, AttributeError):
+    # AttributeError can occur with pyarrow version incompatibilities
     pass
 
 # Apply Lightning patch for manual optimization parameter support

--- a/stable_pretraining/__init__.py
+++ b/stable_pretraining/__init__.py
@@ -7,6 +7,24 @@ os.environ["LOGURU_LEVEL"] = os.environ.get("LOGURU_LEVEL", "INFO")
 
 import logging
 import sys
+
+from loguru import logger
+
+# Handle optional dependencies early
+try:
+    import sklearn.base  # noqa: F401
+
+    SKLEARN_AVAILABLE = True
+except ImportError:
+    SKLEARN_AVAILABLE = False
+
+try:
+    import wandb  # noqa: F401
+
+    WANDB_AVAILABLE = True
+except ImportError:
+    WANDB_AVAILABLE = False
+
 from . import backbone, callbacks, data, losses, module, optim, static, utils
 from .__about__ import (
     __author__,
@@ -16,7 +34,6 @@ from .__about__ import (
     __url__,
     __version__,
 )
-from .utils.lightning_patch import apply_manual_optimization_patch
 from .backbone.utils import TeacherStudentWrapper
 from .callbacks import (
     EarlyStopping,
@@ -28,48 +45,59 @@ from .callbacks import (
     OnlineProbe,
     OnlineWriter,
     RankMe,
-    SklearnCheckpoint,
     TeacherStudentCallback,
     TrainerInfo,
 )
 from .manager import Manager
 from .module import Module
+from .utils.lightning_patch import apply_manual_optimization_patch
+
+# Conditionally import callbacks that depend on optional packages
+if SKLEARN_AVAILABLE:
+    from .callbacks import SklearnCheckpoint
+else:
+    SklearnCheckpoint = None
 
 __all__ = [
-    OnlineProbe,
-    SklearnCheckpoint,
-    OnlineKNN,
-    TrainerInfo,
-    LoggingCallback,
-    ModuleSummary,
-    EarlyStopping,
-    OnlineWriter,
-    RankMe,
-    LiDAR,
-    ImageRetrieval,
-    TeacherStudentCallback,
-    utils,
-    data,
-    module,
-    static,
-    utils,
-    optim,
-    losses,
-    callbacks,
-    Manager,
-    backbone,
-    Module,
-    TeacherStudentWrapper,
-    __author__,
-    __license__,
-    __summary__,
-    __title__,
-    __url__,
-    __version__,
+    # Availability flags
+    "SKLEARN_AVAILABLE",
+    "WANDB_AVAILABLE",
+    # Callbacks
+    "OnlineProbe",
+    "SklearnCheckpoint",
+    "OnlineKNN",
+    "TrainerInfo",
+    "LoggingCallback",
+    "ModuleSummary",
+    "EarlyStopping",
+    "OnlineWriter",
+    "RankMe",
+    "LiDAR",
+    "ImageRetrieval",
+    "TeacherStudentCallback",
+    # Modules
+    "utils",
+    "data",
+    "module",
+    "static",
+    "optim",
+    "losses",
+    "callbacks",
+    "backbone",
+    # Classes
+    "Manager",
+    "Module",
+    "TeacherStudentWrapper",
+    # Package info
+    "__author__",
+    "__license__",
+    "__summary__",
+    "__title__",
+    "__url__",
+    "__version__",
 ]
 
 # Setup logging
-from loguru import logger
 
 # Try to install richuru for better formatting if available
 try:

--- a/stable_pretraining/backbone/__init__.py
+++ b/stable_pretraining/backbone/__init__.py
@@ -1,4 +1,12 @@
-from . import mae
+# Try to import mae if timm is available
+try:
+    from . import mae
+
+    _MAE_AVAILABLE = True
+except ImportError:
+    mae = None
+    _MAE_AVAILABLE = False
+
 from .convmixer import ConvMixer
 from .mlp import MLP
 from .resnet9 import Resnet9
@@ -19,5 +27,7 @@ __all__ = [
     EvalOnly,
     set_embedding_dim,
     ConvMixer,
-    mae,
 ]
+
+if _MAE_AVAILABLE:
+    __all__.append("mae")


### PR DESCRIPTION
Split dependencies in pyproject.toml into:
- Core: minimal required (torch, torchvision, lightning, hydra-core, loguru)
- Optional groups: vision, tracking, cluster, visualization, datasets, extras
- Users can now install only what they need: pip install -e ".[vision,tracking]"

This reduces installation size and makes dependencies clearer for users.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
