### PR TITLE
[WIP] SwAV Implementation

### DIFF
--- a/benchmarks/cifar10/swav-resnet18.py
+++ b/benchmarks/cifar10/swav-resnet18.py
@@ -1,0 +1,195 @@
+"""SwAV training on CIFAR10."""
+
+import lightning as pl
+import torch
+import torchmetrics
+import torchvision
+from lightning.pytorch.loggers import WandbLogger
+from torch import nn
+
+import stable_pretraining as spt
+from stable_pretraining.forward import swav_forward
+from stable_pretraining.data import transforms
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+from utils import get_data_dir
+
+
+class FreezePrototypesCallback(pl.Callback):
+    """Freeze the prototypes layer for the first few epochs."""
+
+    def __init__(self, freeze_epochs=1):
+        self.freeze_epochs = freeze_epochs
+
+    def on_before_optimizer_step(self, trainer, pl_module, optimizer):
+        """Zero out the gradients for the prototypes layer if within freeze_epochs."""
+        if trainer.current_epoch < self.freeze_epochs:
+            for param in pl_module.prototypes.parameters():
+                if param.grad is not None:
+                    param.grad.zero_()
+
+
+BATCH_SIZE = 256
+MAX_EPOCHS = 100
+WARMUP_EPOCHS = 10
+END_LR = 6e-4 if BATCH_SIZE <= 256 else 4.8e-3  # Parameters used in the original paper
+LR = 0.6 if BATCH_SIZE <= 256 else 4.8  # Parameters used in the original paper
+# Queue parameters from the paper
+USE_QUEUE = True if BATCH_SIZE < 256 else False
+QUEUE_LENGTH = 3840
+START_QUEUE_AT_EPOCH = 15
+PROJECTION_DIM = 128  # The output of the projector
+
+swav_transform = transforms.MultiViewTransform(
+    [
+        transforms.Compose(
+            transforms.RGB(),
+            transforms.RandomResizedCrop(32, scale=(0.2, 1.0)),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.ColorJitter(
+                brightness=0.8, contrast=0.8, saturation=0.8, hue=0.2, p=0.8
+            ),
+            transforms.RandomGrayscale(p=0.2),
+            transforms.ToImage(**spt.data.static.CIFAR10),
+        ),
+        transforms.Compose(
+            transforms.RGB(),
+            transforms.RandomResizedCrop(32, scale=(0.2, 1.0)),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.ColorJitter(
+                brightness=0.8, contrast=0.8, saturation=0.8, hue=0.2, p=0.8
+            ),
+            transforms.RandomGrayscale(p=0.2),
+            transforms.GaussianBlur(kernel_size=3, p=0.5),
+            transforms.ToImage(**spt.data.static.CIFAR10),
+        ),
+    ]
+)
+
+val_transform = transforms.Compose(
+    transforms.RGB(),
+    transforms.Resize((32, 32)),
+    transforms.ToImage(**spt.data.static.CIFAR10),
+)
+
+data_dir = get_data_dir("cifar10")
+cifar_train = torchvision.datasets.CIFAR10(
+    root=str(data_dir), train=True, download=True
+)
+cifar_val = torchvision.datasets.CIFAR10(root=str(data_dir), train=False, download=True)
+
+train_dataset = spt.data.FromTorchDataset(
+    cifar_train,
+    names=["image", "label"],
+    transform=swav_transform,
+)
+val_dataset = spt.data.FromTorchDataset(
+    cifar_val,
+    names=["image", "label"],
+    transform=val_transform,
+)
+
+train_dataloader = torch.utils.data.DataLoader(
+    dataset=train_dataset,
+    sampler=spt.data.sampler.RepeatedRandomSampler(train_dataset, n_views=2),
+    batch_size=256,
+    num_workers=8,
+    drop_last=True,
+)
+val_dataloader = torch.utils.data.DataLoader(
+    dataset=val_dataset,
+    batch_size=256,
+    num_workers=10,
+)
+
+data = spt.data.DataModule(train=train_dataloader, val=val_dataloader)
+
+backbone = spt.backbone.from_torchvision(
+    "resnet18",
+    low_resolution=True,
+)
+backbone.fc = torch.nn.Identity()
+
+projector = nn.Sequential(
+    nn.Linear(512, 2048),
+    nn.BatchNorm1d(2048),
+    nn.ReLU(inplace=True),
+    nn.Linear(2048, 128),
+)
+
+prototypes = nn.Linear(128, 3000, bias=False)
+
+steps_per_epoch = len(train_dataloader)
+total_steps = MAX_EPOCHS * steps_per_epoch
+peak_step_for_warmup = WARMUP_EPOCHS * steps_per_epoch
+
+module = spt.Module(
+    backbone=backbone,
+    projector=projector,
+    prototypes=prototypes,
+    forward=swav_forward,
+    use_queue=USE_QUEUE,
+    queue_length=QUEUE_LENGTH,
+    start_queue_at_epoch=START_QUEUE_AT_EPOCH,
+    projection_dim=PROJECTION_DIM,
+    swav_loss=spt.losses.SwAVLoss(
+        temperature=0.1,
+        sinkhorn_iterations=3,
+    ),
+    optim={
+        "optimizer": {
+            "type": "LARS",
+            "lr": LR,
+            "weight_decay": 1e-6,
+        },
+        "scheduler": {
+            "type": "LinearWarmupCosineAnnealing",
+            "peak_step": peak_step_for_warmup,
+            "total_steps": total_steps,
+            "end_lr": END_LR,
+        },
+        "interval": "step",
+    },
+)
+
+linear_probe = spt.callbacks.OnlineProbe(
+    name="linear_probe",
+    input="embedding",
+    target="label",
+    probe=torch.nn.Linear(512, 10),
+    loss_fn=torch.nn.CrossEntropyLoss(),
+    metrics={
+        "top1": torchmetrics.classification.MulticlassAccuracy(10),
+        "top5": torchmetrics.classification.MulticlassAccuracy(10, top_k=5),
+    },
+)
+
+knn_probe = spt.callbacks.OnlineKNN(
+    name="knn_probe",
+    input="embedding",
+    target="label",
+    queue_length=20000,
+    metrics={"accuracy": torchmetrics.classification.MulticlassAccuracy(10)},
+    input_dim=512,
+    k=10,
+)
+
+wandb_logger = WandbLogger(
+    entity="stable-ssl",
+    project="cifar10-swav",
+    log_model=False,
+)
+
+trainer = pl.Trainer(
+    max_epochs=MAX_EPOCHS,
+    num_sanity_val_steps=0,
+    callbacks=[knn_probe, linear_probe, FreezePrototypesCallback(freeze_epochs=2)],
+    precision="16-mixed",  # Unstable, specially with higher lr
+    logger=wandb_logger,
+    enable_checkpointing=False,
+)
+
+manager = spt.Manager(trainer=trainer, module=module, data=data)
+manager()

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -86,3 +86,12 @@
   pages={9588--9597},
   year={2021}
 }
+
+@article{caron2020unsupervised,
+  title={Unsupervised learning of visual features by contrasting cluster assignments},
+  author={Caron, Mathilde and Misra, Ishan and Mairal, Julien and Goyal, Priya and Bojanowski, Piotr and Joulin, Armand},
+  journal={Advances in neural information processing systems},
+  volume={33},
+  pages={9912--9924},
+  year={2020}
+}

--- a/stable_pretraining/losses.py
+++ b/stable_pretraining/losses.py
@@ -226,3 +226,96 @@ class BarlowTwinsLoss(torch.nn.Module):
         off_diag = off_diagonal(c).pow(2).sum()
         loss = on_diag + self.lambd * off_diag
         return loss
+
+
+class SwAVLoss(torch.nn.Module):
+    """Computes the SwAV loss, optionally using a feature queue.
+
+    This loss function contains the core components of the SwAV algorithm, including
+    the Sinkhorn-Knopp algorithm for online clustering and the swapped-prediction
+    contrastive task.
+
+    Args:
+        temperature (float, optional): The temperature scaling factor for the softmax
+            in the swapped prediction task. Default is 0.1.
+        sinkhorn_iterations (int, optional): The number of iterations for the
+            Sinkhorn-Knopp algorithm. Default is 3.
+        epsilon (float, optional): A small value for numerical stability in the
+            Sinkhorn-Knopp algorithm. Default is 0.05.
+
+    Note:
+        Introduced in the SwAV paper :cite:`caron2020unsupervised`.
+    """
+
+    def __init__(
+        self,
+        temperature: float = 0.1,
+        sinkhorn_iterations: int = 3,
+        epsilon: float = 0.05,
+    ):
+        super().__init__()
+        self.temperature = temperature
+        self.sinkhorn_iterations = sinkhorn_iterations
+        self.epsilon = epsilon
+
+    def forward(self, proj1, proj2, prototypes, queue_feats=None):
+        """Compute the SwAV loss.
+
+        Args:
+        proj1 (torch.Tensor): Raw projections of the first view.
+        proj2 (torch.Tensor): Raw projections of the second view.
+        prototypes (torch.nn.Module): The prototype vectors.
+        queue_feats (torch.Tensor, optional): Raw features from the queue.
+        """
+        proj1 = F.normalize(proj1, dim=1, p=2)
+        proj2 = F.normalize(proj2, dim=1, p=2)
+        if queue_feats is not None:
+            queue_feats = F.normalize(queue_feats, dim=1, p=2)
+
+        with torch.no_grad():
+            w = prototypes.weight.data.clone()
+            w = F.normalize(w, dim=1, p=2)
+            prototypes.weight.copy_(w)
+
+        scores1 = prototypes(proj1)
+        scores2 = prototypes(proj2)
+
+        with torch.no_grad():
+            if queue_feats is not None:
+                combined_feats = torch.cat([proj1, proj2, queue_feats])
+                combined_scores = prototypes(combined_feats)
+                all_q = self.sinkhorn(combined_scores)
+                q1 = all_q[: proj1.shape[0]]
+                q2 = all_q[proj1.shape[0] : proj1.shape[0] * 2]
+            else:
+                batch_scores = torch.cat([scores1, scores2])
+                all_q = self.sinkhorn(batch_scores)
+                q1, q2 = all_q.chunk(2)
+
+        loss = self.swapped_prediction(scores1, q2) + self.swapped_prediction(
+            scores2, q1
+        )
+        return loss / 2.0
+
+    def swapped_prediction(self, scores, q):
+        """Computes the cross-entropy loss for the swapped prediction task."""
+        scores = scores.float()
+        loss = -torch.mean(
+            torch.sum(q * F.log_softmax(scores / self.temperature, dim=1), dim=1)
+        )
+        return loss
+
+    @torch.no_grad()
+    def sinkhorn(self, scores):
+        """Applies the Sinkhorn-Knopp algorithm."""
+        scores = scores.float()
+        Q = torch.exp(scores / self.epsilon).T
+        Q /= torch.sum(Q)
+        K, B = Q.shape
+        r = torch.ones(K, device=Q.device) / K
+        c = torch.ones(B, device=Q.device) / B
+        for _ in range(self.sinkhorn_iterations):
+            u = torch.sum(Q, dim=1)
+            Q *= (r / u).unsqueeze(1)
+            Q *= (c / torch.sum(Q, dim=0)).unsqueeze(0)
+        return (Q / torch.sum(Q, dim=0, keepdim=True)).T


### PR DESCRIPTION
## Description
Implementation of SwAV method. Local crops are missing for now, model is working only with global crops.
Also, it was only tested on Cifar10 for now.

<!--- What types of changes does your code introduce? -->
Creation of swav forward and loss, and benchmark for cifar.

The model has some numerical instability when using 16-mixed precision, loss becomes NaN after some epochs, specially when using higher LR. The parameters were set accordingly to what they describe in the paper, freezing prototypes for the first epochs and  using a queue composed of feature representations from previous batches when using small batches, such as 256.

The authors use a LR of 0.6 in LARS when using small batches, which don't cause numerical instability for mixed-16, but takes a long time to converge. I tested on cifar for 100 epochs using 0.6 as LR:
<img width="397" height="228" alt="image" src="https://github.com/user-attachments/assets/d33b7bb7-bf21-4c7f-b2d7-7902faaac526" />

When using a LR of 4.8, it converges much faster, but I have to use float32 (pic below). Not sure if introducing the global crops would solve the instability/convergence or not, I couldn't implement it yet.
<img width="379" height="229" alt="image" src="https://github.com/user-attachments/assets/5075f8fd-60ba-4f0e-82fe-417afb1c5852" />

<!--- Please link to an existing issue here if one exists. -->
https://github.com/rbalestr-lab/stable-pretraining/issues/161

## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [X] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
