### PR TITLE
Rename stable-ssl to stable-pretraining in test README

### DIFF
--- a/stable_pretraining/tests/README.md
+++ b/stable_pretraining/tests/README.md
@@ -1,4 +1,4 @@
-# stable-ssl Test Suite
+# stable-pretraining Test Suite
 
 ## Structure
 
@@ -87,20 +87,20 @@ python -m pytest --cov=stable_pretraining -m unit
 ```python
 import pytest
 import torch
-import stable_pretraining as ossl
+import stable_pretraining as spt
 
 
 @pytest.mark.unit
 class TestMyComponent:
     def test_initialization(self):
         # Test without GPU or data
-        component = ossl.MyComponent(param=10)
+        component = spt.MyComponent(param=10)
         assert component.param == 10
 
     def test_forward_mock(self):
         # Use mock data
         mock_input = torch.randn(4, 3, 32, 32)
-        component = ossl.MyComponent()
+        component = spt.MyComponent()
         output = component(mock_input)
         assert output.shape == (4, 10)
 ```
@@ -108,7 +108,7 @@ class TestMyComponent:
 ### Integration Test Example
 ```python
 import pytest
-import stable_pretraining as ossl
+import stable_pretraining as spt
 
 
 @pytest.mark.integration
@@ -116,7 +116,7 @@ import stable_pretraining as ossl
 @pytest.mark.download
 def test_full_training():
     # Test with real data and GPU
-    dataset = ossl.data.HFDataset(
+    dataset = spt.data.HFDataset(
         path="frgfm/imagenette",
         split="train",
         transform=transform


### PR DESCRIPTION
Updated references from 'ossl' to 'spt' in README.md.

## Description

<!--- What types of changes does your code introduce? -->
This pull request updates the test documentation for the `stable_pretraining` package to reflect recent changes in naming conventions. The main change is the replacement of the old import alias `ossl` with the new `spt` throughout the test examples, and an update to the test suite name for clarity.

Documentation updates:

* Renamed the test suite in `stable_pretraining/tests/README.md` from "stable-ssl" to "stable-pretraining" to match the current package name.

Code sample consistency:

* Updated all test code examples in `stable_pretraining/tests/README.md` to import the package as `spt` instead of `ossl`, ensuring consistency with the new naming convention.
<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
