### PR TITLE
add pypi publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Publish on any tag starting with a `v`, e.g., v1.2.3
+      - v*
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    # Environment and permissions trusted publishing.
+    environment:
+      # Create this environment in the GitHub repository under Settings -> Environments
+      name: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install Python 3.10
+        run: uv python install 3.10
+      - name: Build
+        run: uv build
+      # Check that basic features work and we didn't miss to include crucial files
+      # - name: Smoke test (wheel)
+      #   run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
+      # - name: Smoke test (source distribution)
+      #   run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+      - name: Publish
+        run: uv publish

--- a/stable_pretraining/__about__.py
+++ b/stable_pretraining/__about__.py
@@ -7,9 +7,9 @@ __all__ = [
     "__url__",
 ]
 
-__title__ = "stable-ssl"
+__title__ = "stable-pretraining"
 __summary__ = "Self-Supervised Learning Research Library"
-__version__ = "0.0.1.dev0"
+__version__ = "v0.0.1"
 __author__ = "Randall Balestriero, Hugues Van Assel, Lucas Maes"
 __license__ = "MIT"
-__url__ = "https://rbalestr-lab.github.io/stable-SSL.github.io/"
+__url__ = "https://rbalestr-lab.github.io/stable-pretraining.github.io"


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->
This pull request introduces a new release workflow and updates the project metadata to reflect the correct name and versioning for the library. The most important changes are grouped below:

Release automation:

* Added a new GitHub Actions workflow in `.github/workflows/release.yaml` to automate publishing to PyPI when a new version tag is pushed. This workflow uses trusted publishing with the `uv` toolchain and sets up the required environment and permissions.

Project metadata updates:

* Updated the library title in `stable_pretraining/__about__.py` from `"stable-ssl"` to `"stable-pretraining"` to match the repository and package naming.
* Changed the version string in `stable_pretraining/__about__.py` from `"0.0.1.dev0"` to `"v0.0.1"` to indicate the first release version.
* Updated the project URL in `stable_pretraining/__about__.py` to point to the correct documentation site for stable-pretraining.

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
