### PR TITLE
patch import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "hydra-core",
     "loguru",
     "tabulate",
+    "pandas",
+    "rich",
+    "requests-cache",
+    "prettytable",
+    "submitit",
 ]
 
 dynamic = ["version"]
@@ -51,13 +56,11 @@ tracking = [
 # Cluster/SLURM execution support
 cluster = [
     "hydra-submitit-launcher",
-    "submitit",
 ]
 
 # Visualization and reporting tools
 visualization = [
     "matplotlib",
-    "prettytable",
 ]
 
 # Extra dataset support
@@ -70,7 +73,6 @@ datasets = [
 # Additional utilities
 extras = [
     "scikit-learn>=1.7.0",  # sklearn model checkpointing
-    "requests-cache[all]",  # Caching for API requests
     "richuru",  # Enhanced logging formatting
 ]
 

--- a/stable_pretraining/utils/__init__.py
+++ b/stable_pretraining/utils/__init__.py
@@ -39,7 +39,6 @@ from .inspection_utils import (
     get_required_fn_parameters,
 )
 from .nn_modules import EMA, ImageToVideoEncoder, Normalize, OrderedQueue, UnsortedQueue
-from .visualization import imshow_with_grid, visualize_images_graph
 
 __all__ = [
     # autograd


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->
This pull request updates project dependencies in `pyproject.toml` and makes a small cleanup in the `stable_pretraining/utils/__init__.py` file. The main changes involve moving several packages from optional dependency groups to the core dependencies list, streamlining package management and ensuring these libraries are always available.

**Dependency management updates:**

* Added `pandas`, `rich`, `requests-cache`, `prettytable`, and `submitit` to the main `dependencies` list, making them required for all installations.
* Removed `submitit` from the `cluster` optional group and `prettytable` from the `visualization` optional group, since they are now core dependencies.
* Removed `requests-cache[all]` from the `extras` group, as `requests-cache` is now a core dependency.

**Codebase cleanup:**

* Removed the import of `imshow_with_grid` and `visualize_images_graph` from `.visualization` in `stable_pretraining/utils/__init__.py`, likely because these functions are no longer needed or available.
<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
