### PR TITLE
[BugFix] Fix WandB config sync for pre-instantiated loggers

### DIFF
--- a/stable_pretraining/manager.py
+++ b/stable_pretraining/manager.py
@@ -151,13 +151,7 @@ class Manager(submitit.helpers.Checkpointable):
             logging.info("📈📈📈 WandbLogger already setup, syncing config 📈📈📈")
             logging.info(f"📈📈📈 init={self.trainer.logger._wandb_init} 📈📈📈")
             # Logger was pre-instantiated (e.g., by Hydra) - sync config and return
-            if WANDB_AVAILABLE and wandb.run:
-                if len(wandb.config.keys()):
-                    logging.info(
-                        "\t\ta Wandb™ config is provided (sweep mode), skipping Hydra config upload"
-                    )
-                else:
-                    self._upload_hydra_config_to_wandb()
+            self._upload_hydra_config_to_wandb()
             return
         elif self.trainer.logger is None:
             logging.warning("📈📈📈 No logger used! 📈📈📈")
@@ -194,12 +188,8 @@ class Manager(submitit.helpers.Checkpointable):
             # at most last_config has an extra `ckpt_path`
             exp.config.update(last_config)
             logging.info("\t\treloaded!")
-        elif WANDB_AVAILABLE and wandb.run and len(wandb.config.keys()):
-            logging.info(
-                "\t\ta Wandb™ config is provided (sweep mode), not uploading Hydra's"
-            )
         else:
-            # WandB sweep not active, upload Hydra config
+            # Upload Hydra config (WandB handles merging with sweep params)
             self._upload_hydra_config_to_wandb()
 
     @property


### PR DESCRIPTION
Problem:
When WandbLogger is pre-instantiated by Hydra (via _target_ in config), stable-pretraining hits an early return and skips uploading Hydra config to wandb.config. This prevents filtering/grouping runs by hyperparameters in the WandB UI.

Solution:
1. Extract config upload logic into _upload_hydra_config_to_wandb() helper
2. Call helper when WandbLogger is already instantiated (before early return)
3. Remove unnecessary config flattening - WandB handles nested dicts natively
4. Clean up commented-out code

Benefits:
- Config syncs regardless of when/how logger is instantiated
- Simpler code (removed ~50 lines of flattening/commented logic)
- More readable WandB configs (nested structure preserved)
- Backwards compatible with existing behavior

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
