### PR TITLE
[BugFix] Fix callback parameter name: use 'module' instead of 'pl_module'

### DIFF
--- a/stable_pretraining/manager.py
+++ b/stable_pretraining/manager.py
@@ -186,8 +186,8 @@ class Manager(submitit.helpers.Checkpointable):
                 for i, callback in enumerate(callbacks):
                     if not callable(callback):
                         continue
-                    assert ["pl_module"] == get_required_fn_parameters(callback)
-                    callbacks[i] = callback(pl_module=self.instantiated_module)
+                    assert ["module"] == get_required_fn_parameters(callback)
+                    callbacks[i] = callback(module=self.instantiated_module)
                 logging.info("\t● callbacks instantiated ✅")
                 del self.trainer.callbacks
 


### PR DESCRIPTION
The manager was incorrectly trying to inject 'pl_module' into partial callbacks, but all callbacks (OnlineProbe, OnlineKNN, etc.) expect 'module' as the parameter name.

This caused an AssertionError when using partial callbacks with _partial_: true in Hydra configs.

Fixes parameter name mismatch between manager injection and callback signatures.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
