### PR TITLE
[BugFix] Make instantiation warnings and config printing rank-zero-only

### DIFF
--- a/stable_pretraining/config.py
+++ b/stable_pretraining/config.py
@@ -1,10 +1,10 @@
 """Configuration classes specifying default parameters for stable-SSL."""
 
-import logging
 from typing import Any, Union
 
 import hydra
 import omegaconf
+from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
 
 def collapse_nested_dict(
@@ -111,7 +111,7 @@ def recursive_instantiate(
                 else:
                     instantiated[key] = cfg[key]
             except Exception as e:
-                logging.warning(f"Could not instantiate {key}: {e}")
+                rank_zero_warn(f"Could not instantiate {key}: {e}")
                 instantiated[key] = cfg[key]
 
     # Second pass: instantiate remaining components
@@ -126,7 +126,7 @@ def recursive_instantiate(
                 else:
                     instantiated[key] = value
             except Exception as e:
-                logging.warning(f"Could not instantiate {key}: {e}")
+                rank_zero_warn(f"Could not instantiate {key}: {e}")
                 instantiated[key] = value
 
     return instantiated

--- a/stable_pretraining/run.py
+++ b/stable_pretraining/run.py
@@ -21,8 +21,19 @@ Usage:
 
 import hydra
 from omegaconf import DictConfig, OmegaConf
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 
 from .config import instantiate_from_config
+
+
+@rank_zero_only
+def print_config(cfg: DictConfig) -> None:
+    """Print configuration only on rank 0."""
+    print("=" * 80)
+    print("Configuration:")
+    print("=" * 80)
+    print(OmegaConf.to_yaml(cfg))
+    print("=" * 80)
 
 
 @hydra.main(version_base="1.3", config_path=None, config_name=None)
@@ -32,12 +43,8 @@ def main(cfg: DictConfig) -> None:
     Args:
         cfg: Hydra configuration dictionary containing all experiment parameters
     """
-    # Print configuration for debugging
-    print("=" * 80)
-    print("Configuration:")
-    print("=" * 80)
-    print(OmegaConf.to_yaml(cfg))
-    print("=" * 80)
+    # Print configuration for debugging (only on rank 0)
+    print_config(cfg)
 
     # Instantiate and run
     manager = instantiate_from_config(cfg)


### PR DESCRIPTION
- Replace logging.warning with rank_zero_warn in config.py to prevent instantiation warnings from appearing on all ranks
- Add rank_zero_only decorator to config printing in run.py to avoid printing configuration 4 times in multi-GPU setup

This reduces console clutter when running distributed training.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
