### PR TITLE
[BugFix] Fix AMP with multiple optimizers in manual optimization

### DIFF
--- a/stable_pretraining/module.py
+++ b/stable_pretraining/module.py
@@ -251,8 +251,8 @@ class Module(pl.LightningModule):
                         gradient_clip_algorithm=clip_algo,
                     )
 
-                # Step using raw optimizer to bypass Lightning's scaler.update()
-                scaler.step(opt.optimizer)
+                # Step optimizer (scaler must use same object as unscale_)
+                scaler.step(opt)
                 zero_grad_opts.append(opt)
 
                 # Step scheduler


### PR DESCRIPTION
Fix AssertionError when using multiple optimizers (main + callbacks) with precision=16-mixed: 'No inf checks were recorded for this optimizer'

Root cause:
- Lightning's precision plugin calls scaler.update() after EACH optimizer
- PyTorch requires scaler.update() to be called ONCE after ALL optimizers
- With multiple optimizers, the first optimizer's update() clears the scaler state, causing the second optimizer to fail

Solution:
- Detect when using AMP (fp16-mixed) with multiple optimizers
- Manually handle the scaler lifecycle:
  1. unscale_() all optimizers before any step
  2. step() each optimizer
  3. update() ONCE after all optimizers
- Single optimizer or non-AMP cases use normal Lightning path

This follows PyTorch AMP best practices from the official documentation: https://pytorch.org/docs/stable/notes/amp_examples.html#working-with-multiple-models-losses-and-optimizers

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
