### PR TITLE
[Feature] Add matmul_precision config parameter for TF32 control

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2,6 +2,7 @@
 Version 0.1
 -----------
 
+- Added `matmul_precision` config parameter to control TensorFloat-32 (TF32) precision on Ampere and newer GPUs.
 - Base trainer offering the basic functionalities of stable-SSL (logging, checkpointing, data loading etc).
 - Template trainers for supervised and self-supervised learning (general joint embedding, JEPA, and teacher student models).
 - Examples of self-supervised learning methods : SimCLR, Barlow Twins, VicReg, DINO, MoCo, SimSiam.

--- a/stable_pretraining/config.py
+++ b/stable_pretraining/config.py
@@ -148,10 +148,16 @@ def instantiate_from_config(cfg: Union[dict, omegaconf.DictConfig]) -> Any:
         otherwise returns instantiated config dict
     """
     from stable_pretraining.manager import Manager
+    import torch
 
     # Convert to DictConfig if needed
     if isinstance(cfg, dict):
         cfg = omegaconf.OmegaConf.create(cfg)
+
+    # Set matmul precision if specified (must be done before Trainer instantiation)
+    if "matmul_precision" in cfg and cfg.matmul_precision is not None:
+        torch.set_float32_matmul_precision(cfg.matmul_precision)
+        rank_zero_warn(f"Set float32 matmul precision to: {cfg.matmul_precision}")
 
     # Instantiate all components
     components = recursive_instantiate(cfg)


### PR DESCRIPTION
- Added matmul_precision parameter to instantiate_from_config()
- Allows setting torch.set_float32_matmul_precision() via config
- Useful for enabling TF32 on Ampere+ GPUs (A100, H100, B200)
- Updated RELEASES.rst

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
