### PR TITLE
[BugFix] Fix module config interpolation resolution

### DIFF
--- a/stable_pretraining/config.py
+++ b/stable_pretraining/config.py
@@ -86,7 +86,10 @@ def recursive_instantiate(
                 ):
                     # Special handling for Module to resolve forward function
                     if key == "module" and "forward" in cfg[key]:
-                        module_cfg = dict(cfg[key])
+                        # Resolve interpolations before converting to dict to handle root-level references
+                        module_cfg = omegaconf.OmegaConf.to_container(
+                            cfg[key], resolve=True
+                        )
                         # Import the forward function if it's a string reference
                         if isinstance(module_cfg["forward"], str):
                             parts = module_cfg["forward"].rsplit(".", 1)


### PR DESCRIPTION
When special handling is applied to resolve the forward function string, the config is converted from DictConfig to dict. Using dict() loses the connection to the root config, causing interpolations that reference root-level variables (e.g., ${scaled_lr}) to fail during recursive instantiation.

Changed to use OmegaConf.to_container(resolve=True) which resolves all interpolations while still having access to the root config, then converts to a plain dict.

This enables patterns like:
  - Root level: scaled_lr: ${eval:'${base_lr} * 16'}
  - Module level: lr: ${scaled_lr}

Fixes issues where module instantiation fails with unresolved interpolations during sweep configurations.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
