### PR TITLE
[BugFix] no optimizer module should return state

### DIFF
--- a/stable_pretraining/module.py
+++ b/stable_pretraining/module.py
@@ -186,7 +186,7 @@ class Module(pl.LightningModule):
         optimizers = self.optimizers()
         # there are NO optimizers either from main or callbacks, no need to stay here!
         if isinstance(optimizers, pl.pytorch.core.optimizer._MockOptimizer):
-            return
+            return state
         elif not isinstance(optimizers, (list, tuple)):
             optimizers = [optimizers]
 


### PR DESCRIPTION
This pull request makes a minor change to the `training_step` method in `stable_pretraining/module.py`. The change ensures that the method returns the `state` object instead of returning nothing when a mock optimizer is detected. This helps maintain consistent return values and may prevent issues in downstream code.

* Changed the return value in the `training_step` method to return `state` when the optimizer is a `_MockOptimizer`, improving consistency in method behavior.

It's required for Writer callback to work properly