### PR TITLE
Fix code in case of single optimizer

### DIFF
--- a/stable_pretraining/module.py
+++ b/stable_pretraining/module.py
@@ -251,6 +251,11 @@ class Module(pl.LightningModule):
     def on_train_start(self):
         logging.info("Double checking optimizers!")
         optimizers = self.optimizers()
+        
+        # Quick fix if optimizer is not a tuple/list
+        if not isinstance(optimizers, (list, tuple)):
+            optimizers = [optimizers]
+        
         logging.info(f"`self.optimizers() gave us {len(optimizers)} optimizers")
         for i in range(len(optimizers)):
             # check if optimizer i is named and well setup


### PR DESCRIPTION
Ensure self.optimizers() is always treated as a list in module.training_step(self, batch, batch_idx):

## Description

Currently, self.optimizers() may return a single LightningAdamW optimizer or a list/tuple of optimizers. The existing code assumes it’s always a list, which causes a TypeError when calling len() on a single optimizer.

This PR modifies the code to wrap the optimizer in a list if it isn’t already a list/tuple. This ensures downstream code can safely iterate over optimizers regardless of whether there is one or multiple optimizers.


## Changes (starting line 253)

```python
optimizers = self.optimizers()
        
+++ # Quick fix if optimizer is not a tuple/list
+++ if not isinstance(optimizers, (list, tuple)):
+++     optimizers = [optimizers]

 logging.info(f"`self.optimizers() gave us {len(optimizers)} optimizers")
```

## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [] All tests passed, and additional code has been **covered with new tests**.
- [] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
