### PR TITLE
Fix OnlineProbe docstring to document LARS optimizer default

### DIFF
--- a/stable_pretraining/callbacks/probe.py
+++ b/stable_pretraining/callbacks/probe.py
@@ -41,13 +41,14 @@ class OnlineProbe(TrainableCallback):
             - dict: {"type": "AdamW", "lr": 1e-3, ...}
             - partial: pre-configured optimizer factory
             - optimizer instance or callable
-            - None: inherits from main Module's optimizer config (default)
+            - None: uses LARS(lr=0.1, clip_lr=True, eta=0.02, exclude_bias_n_norm=True,
+              weight_decay=0), which is the standard for SSL linear probes (default)
         scheduler: Learning rate scheduler configuration. Can be:
             - str: scheduler name (e.g., "CosineAnnealingLR", "StepLR")
             - dict: {"type": "CosineAnnealingLR", "T_max": 1000, ...}
             - partial: pre-configured scheduler factory
             - scheduler instance or callable
-            - None: inherits from main Module's scheduler config (default)
+            - None: uses ConstantLR(factor=1.0), maintaining constant learning rate (default)
         accumulate_grad_batches: Number of batches to accumulate gradients before
             optimizer step. Default is 1 (no accumulation).
         metrics: Metrics to track during training/validation. Can be dict, list, tuple,

--- a/stable_pretraining/callbacks/utils.py
+++ b/stable_pretraining/callbacks/utils.py
@@ -40,8 +40,8 @@ class TrainableCallback(Callback):
         Args:
             module: spt.Module.
             name: Unique identifier for this callback instance.
-            optimizer: Optimizer configuration. If None, inherits from main module.
-            scheduler: Scheduler configuration. If None, inherits from main module.
+            optimizer: Optimizer configuration. If None, uses default LARS.
+            scheduler: Scheduler configuration. If None, uses default ConstantLR.
             accumulate_grad_batches: Number of batches to accumulate gradients.
             gradient_clip_val: Value to clip the gradient (default None).
             gradient_clip_algorithm: Algorithm to clip the gradient (default `norm`).
@@ -131,9 +131,9 @@ class TrainableCallback(Callback):
         )
 
     def setup_optimizer(self, pl_module: LightningModule) -> None:
-        """Initialize optimizer with inheritance from main module if needed."""
+        """Initialize optimizer with default LARS if not specified."""
         if self._optimizer_config is None:
-            # Try to inherit from main module's optimizer config
+            # Use default LARS optimizer for SSL linear probes
             logging.info(f"{self.name}: No optimizer given, using default LARS")
             return LARS(
                 self.module.parameters(),
@@ -148,10 +148,10 @@ class TrainableCallback(Callback):
         return create_optimizer(self.module.parameters(), self._optimizer_config)
 
     def setup_scheduler(self, optimizer, pl_module: LightningModule) -> None:
-        """Initialize scheduler with inheritance from main module if needed."""
+        """Initialize scheduler with default ConstantLR if not specified."""
         if self._scheduler_config is None:
-            # Fallback to ConstantLR
-            logging.info(f"{self.name}:No optimizer given, using default ConstantLR")
+            # Use default ConstantLR scheduler
+            logging.info(f"{self.name}: No scheduler given, using default ConstantLR")
             return torch.optim.lr_scheduler.ConstantLR(optimizer, factor=1.0)
         logging.info(f"{self.name}: Use explicitly provided scheduler")
         return create_scheduler(optimizer, self._scheduler_config, module=pl_module)


### PR DESCRIPTION
The OnlineProbe docstring incorrectly stated that optimizer=None would inherit from the main module's configuration. In reality, it uses a hardcoded LARS optimizer with specific parameters.

This was causing confusion when users saw different optimizers in logs than what the documentation promised.

Changes:
- Updated OnlineProbe docstring to accurately document LARS default parameters
- Updated TrainableCallback docstring to remove inheritance claims
- Fixed misleading comments in setup methods

Fixes #346