### PR TITLE
[Feature] Add automatic loss logging to all forward functions

### DIFF
--- a/stable_pretraining/callbacks/factories.py
+++ b/stable_pretraining/callbacks/factories.py
@@ -4,14 +4,7 @@ from .env_info import EnvironmentDumpCallback
 
 
 def default():
-    """Factory function that returns callbacks.
-
-    Since Lightning doesn't pass pl_module when loading from entry points,
-    we can't auto-detect TeacherStudent. Returns static callbacks only.
-
-    For auto-detection to work, the TeacherStudentCallback must be added
-    manually in the trainer config or script.
-    """
+    """Factory function that returns default callbacks."""
     callbacks = [
         # RichProgressBar(),
         LoggingCallback(),

--- a/stable_pretraining/forward.py
+++ b/stable_pretraining/forward.py
@@ -76,6 +76,9 @@ def supervised_forward(self, batch, stage):
                 "Pass it when constructing the Module: Module(..., supervised_loss=nn.CrossEntropyLoss(), ...)"
             )
         out["loss"] = self.supervised_loss(out["logits"], batch["label"])
+        self.log(
+            f"{stage}/loss", out["loss"], on_step=True, on_epoch=True, sync_dist=True
+        )
 
     return out
 
@@ -125,6 +128,13 @@ def simclr_forward(self, batch, stage):
         if self.training:
             projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.simclr_loss(projections[0], projections[1])
+            self.log(
+                f"{stage}/loss",
+                out["loss"],
+                on_step=True,
+                on_epoch=True,
+                sync_dist=True,
+            )
     else:
         # Single-view validation
         out["embedding"] = self.backbone(batch["image"])
@@ -211,6 +221,9 @@ def byol_forward(self, batch, stage):
 
         out["embedding"] = torch.cat(target_features, dim=0).detach()
         out["loss"] = loss
+        self.log(
+            f"{stage}/loss", out["loss"], on_step=True, on_epoch=True, sync_dist=True
+        )
 
     else:
         # Single-view validation
@@ -273,6 +286,13 @@ def vicreg_forward(self, batch, stage):
         if self.training:
             projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.vicreg_loss(projections[0], projections[1])
+            self.log(
+                f"{stage}/loss",
+                out["loss"],
+                on_step=True,
+                on_epoch=True,
+                sync_dist=True,
+            )
     else:
         # Single-view validation
         out["embedding"] = self.backbone(batch["image"])
@@ -328,6 +348,13 @@ def barlow_twins_forward(self, batch, stage):
         if self.training:
             projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.barlow_loss(projections[0], projections[1])
+            self.log(
+                f"{stage}/loss",
+                out["loss"],
+                on_step=True,
+                on_epoch=True,
+                sync_dist=True,
+            )
     else:
         # Single-view validation
         out["embedding"] = self.backbone(batch["image"])
@@ -381,6 +408,13 @@ def swav_forward(self, batch, stage):
                 out["swav_queue"] = torch.cat(projections).detach()
 
             out["loss"] = self.swav_loss(proj1, proj2, self.prototypes, queue_feats)
+            self.log(
+                f"{stage}/loss",
+                out["loss"],
+                on_step=True,
+                on_epoch=True,
+                sync_dist=True,
+            )
 
     else:
         out["embedding"] = self.backbone(batch["image"])
@@ -473,6 +507,14 @@ def nnclr_forward(self, batch, stage):
             else:
                 # Fallback to SimCLR style loss if queue is empty
                 out["loss"] = self.nnclr_loss(proj_q, proj_k)
+
+            self.log(
+                f"{stage}/loss",
+                out["loss"],
+                on_step=True,
+                on_epoch=True,
+                sync_dist=True,
+            )
 
             # The key here must match the `key` argument of the `OnlineQueue` callback
             out["nnclr_support_set"] = torch.cat(projections)
@@ -679,6 +721,7 @@ def dino_forward(self, batch, stage):
 
     out["embedding"] = teacher_cls_features.detach()
     out["loss"] = loss
+    self.log(f"{stage}/loss", out["loss"], on_step=True, on_epoch=True, sync_dist=True)
 
     return out
 
@@ -977,5 +1020,6 @@ def dinov2_forward(self, batch, stage):
     # Return flattened CLS features for callbacks (probes expect [n_global * batch_size, dim])
     out["embedding"] = teacher_cls_features.view(n_global * batch_size, -1).detach()
     out["loss"] = loss
+    self.log(f"{stage}/loss", out["loss"], on_step=True, on_epoch=True, sync_dist=True)
 
     return out


### PR DESCRIPTION
## Summary

This PR adds automatic loss logging to all forward functions in `forward.py`, improving the out-of-the-box user experience by providing loss curves without requiring manual logging.

## Changes

### Loss Logging
- Added `self.log()` calls to all forward functions
- Log format: `f"{stage}/loss"` (e.g., `"fit/loss"`, `"validate/loss"`)
- Parameters: `on_step=True, on_epoch=True, sync_dist=True`
- Works with distributed training (syncs across GPUs)

### Methods Updated
- `supervised_forward`
- `simclr_forward`
- `byol_forward`
- `vicreg_forward`
- `barlow_twins_forward`
- `swav_forward`
- `nnclr_forward`
- `dino_forward`
- `dinov2_forward`

### Code Cleanup
- Simplified `callbacks/factories.py` docstring

## Benefits

✅ Better user experience - loss tracking works automatically  
✅ Consistent logging across all SSL methods  
✅ Loss curves automatically available in TensorBoard/WandB  
✅ Distributed training compatible (`sync_dist=True`)  
✅ Both step and epoch metrics logged

## Testing

The logging uses standard PyTorch Lightning patterns already tested in the codebase. No functional changes to the training logic.