### PR TITLE
[WIP][Feature][Bugfix] WandB setup/finish simplified + callback.

### DIFF
--- a/stable_pretraining/__init__.py
+++ b/stable_pretraining/__init__.py
@@ -48,6 +48,7 @@ from .callbacks import (
     RankMe,
     TeacherStudentCallback,
     TrainerInfo,
+    WandbCallback,
 )
 from .callbacks.registry import log
 from .manager import Manager
@@ -77,6 +78,7 @@ __all__ = [
     "LiDAR",
     "ImageRetrieval",
     "TeacherStudentCallback",
+    "WandbCallback",
     # Modules
     "utils",
     "data",

--- a/stable_pretraining/callbacks/__init__.py
+++ b/stable_pretraining/callbacks/__init__.py
@@ -1,8 +1,8 @@
 from .checkpoint_sklearn import (
     SklearnCheckpoint,
-    WandbCheckpoint,
     StrictCheckpointCallback,
 )
+from .wandb_lifecycle import WandbCallback, WandbCheckpoint
 from .image_retrieval import ImageRetrieval
 from .knn import OnlineKNN
 from .latent_viz import LatentViz
@@ -26,6 +26,7 @@ from .unused_parameters import LogUnusedParametersOnce
 __all__ = [
     OnlineProbe,
     SklearnCheckpoint,
+    WandbCallback,
     WandbCheckpoint,
     OnlineKNN,
     LatentViz,

--- a/stable_pretraining/callbacks/checkpoint_sklearn.py
+++ b/stable_pretraining/callbacks/checkpoint_sklearn.py
@@ -227,5 +227,3 @@ class StrictCheckpointCallback(Callback):
             f"📊 Checkpoint loading coverage: {loaded_percentage:.2f}% ({len(matched_keys)}/{total_model_params})"
         )
         logger.info("=" * 80)
-
-

--- a/stable_pretraining/callbacks/checkpoint_sklearn.py
+++ b/stable_pretraining/callbacks/checkpoint_sklearn.py
@@ -4,8 +4,6 @@ import numpy as np
 from lightning.pytorch import Callback, LightningModule, Trainer
 from loguru import logger as logging
 from tabulate import tabulate
-from lightning.pytorch.loggers import WandbLogger
-
 from typing import Any, Dict
 import lightning.pytorch as pl
 from loguru import logger
@@ -231,89 +229,3 @@ class StrictCheckpointCallback(Callback):
         logger.info("=" * 80)
 
 
-class WandbCheckpoint(Callback):
-    """Callback for saving and loading sklearn models in PyTorch Lightning checkpoints.
-
-    This callback automatically detects sklearn models (Regressors and Classifiers)
-    attached to the Lightning module and handles their serialization/deserialization
-    during checkpoint save/load operations. This is necessary because sklearn models
-    are not natively supported by PyTorch's checkpoint system.
-
-    The callback will:
-    1. Automatically discover sklearn models attached to the Lightning module
-    2. Save them to the checkpoint dictionary during checkpoint saving
-    3. Restore them from the checkpoint during checkpoint loading
-    4. Log information about discovered sklearn modules during setup
-
-    Note:
-        - Only attributes that are sklearn RegressorMixin or ClassifierMixin instances are saved
-        - Private attributes (starting with '_') are ignored
-        - The callback will raise an error if a sklearn model name conflicts with existing checkpoint keys
-    """
-
-    def setup(
-        self, trainer: Trainer, pl_module: LightningModule, stage: Optional[str] = None
-    ) -> None:
-        logging.info("Setting up WandbCheckpoint callback!")
-
-    def on_save_checkpoint(self, trainer, pl_module, checkpoint):
-        logging.info("Checking for Wandb params to save... 🔧")
-        if isinstance(trainer.logger, WandbLogger):
-            checkpoint["wandb"] = {"id": trainer.logger.version}
-            # checkpoint["wandb_checkpoint_name"] = trainer.logger._checkpoint_name
-            logging.info(f"Saving Wandb params {checkpoint['wandb']}")
-        logging.info("Checking for Wandb params to save... Done!")
-
-    def on_load_checkpoint(self, trainer, pl_module, checkpoint):
-        logging.info("Checking for Wandb init params... 🔧")
-        if "wandb" in checkpoint:
-            logging.info("Wandb info in checkpoint!!! Restoring same run... 🔧")
-            if not hasattr(trainer, "logger"):
-                logging.warning("Expected Trainer to have a logger, leaving...")
-                return
-            elif not isinstance(trainer.logger, WandbLogger):
-                logging.warning(
-                    f"Expected WandbLogger, got {trainer.logger}, leaving..."
-                )
-                return
-            else:
-                logging.info("Trainer has a WandbLogger!")
-            import wandb
-
-            if wandb.run is None and trainer.global_rank > 0:
-                logging.info(
-                    "Run not initialized yet, skipping since this is a slave process!"
-                )
-                return
-            if wandb.run is not None and wandb.run.id == checkpoint["wandb"]["id"]:
-                logging.info(
-                    "Run already property initialized, skipping deletion and setup!"
-                )
-                return
-            logging.info(
-                f"Deleting current run {wandb.run.entity}/{wandb.run.project}/{wandb.run.id}... 🔧"
-            )
-            api = wandb.Api()
-            run = api.run(f"{wandb.run.entity}/{wandb.run.project}/{wandb.run.id}")
-            wandb.finish()
-            run.delete()
-            trainer.logger._experiment = None
-            wandb_id = checkpoint["wandb"]["id"]
-            trainer.logger._wandb_init["id"] = wandb_id
-            trainer.logger._id = wandb_id
-            # to reset the run
-            trainer.logger.experiment
-            logging.info(
-                f"New run {wandb.run.entity}/{wandb.run.project}/{wandb.run.id}... 🔧"
-            )
-
-            # trainer.logger._wandb_init = wandb_init
-            # trainer.logger._project = trainer.logger._wandb_init.get("project")
-            # trainer.logger._save_dir = trainer.logger._wandb_init.get("dir")
-            # trainer.logger._name = trainer.logger._wandb_init.get("name")
-            # trainer.logger._checkpoint_name = checkpoint["wandb_checkpoint_name"]
-            # logging.info("Updated Wandb parameters: ")
-            # logging.info(f"\t- project={trainer.logger._project}")
-            # logging.info(f"\t- _save_dir={trainer.logger._save_dir}")
-            # logging.info(f"\t- name={trainer.logger._name}")
-            # logging.info(f"\t- id={trainer.logger._id}")

--- a/stable_pretraining/callbacks/factories.py
+++ b/stable_pretraining/callbacks/factories.py
@@ -1,9 +1,10 @@
-from .checkpoint_sklearn import SklearnCheckpoint, WandbCheckpoint
+from .checkpoint_sklearn import SklearnCheckpoint
 from .trainer_info import LoggingCallback, ModuleSummary, TrainerInfo, SLURMInfo
 from .env_info import EnvironmentDumpCallback
 from .registry import ModuleRegistryCallback
 from .unused_parameters import LogUnusedParametersOnce
 from .cpu_offload import CPUOffloadCallback
+from .wandb_lifecycle import WandbCallback, WandbCheckpoint
 
 
 def default():
@@ -15,6 +16,7 @@ def default():
         EnvironmentDumpCallback(async_dump=True),
         TrainerInfo(),
         SklearnCheckpoint(),
+        WandbCallback(),
         WandbCheckpoint(),
         ModuleSummary(),
         SLURMInfo(),

--- a/stable_pretraining/callbacks/wandb_lifecycle.py
+++ b/stable_pretraining/callbacks/wandb_lifecycle.py
@@ -1,0 +1,384 @@
+import json
+from pathlib import Path
+from typing import Optional
+
+from lightning.pytorch import Callback, LightningModule, Trainer
+from lightning.pytorch.loggers import WandbLogger
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
+from loguru import logger as logging
+from omegaconf import DictConfig, OmegaConf
+
+from .. import WANDB_AVAILABLE
+
+if WANDB_AVAILABLE:
+    import wandb
+else:
+    wandb = None
+
+
+class WandbCallback(Callback):
+    """Manage the wandb run lifecycle: init, config sync, and teardown.
+
+    This callback consolidates wandb-specific logic. 
+    It handles the following concerns:
+
+    1. **Run initialization** -- On ``setup()``, triggers ``wandb.init()``
+       via the trainer's ``WandbLogger`` and captures the run ID for
+       later use.
+    2. **Config sync** -- Uploads the Hydra ``DictConfig`` to wandb by
+       flattening nested dicts into dot-separated keys.  For offline
+       runs that are being resumed (SLURM requeue), reloads the config
+       from the previous offline run directory instead.
+    3. **Offline data persistence** -- On ``teardown()``, writes
+       ``wandb-summary.json`` and ``wandb-config.json`` into the wandb
+       run directory so that offline runs can be synced or inspected.
+    4. **Clean shutdown** -- Calls ``wandb.finish()`` on ``teardown()``
+       and resets the logger so a subsequent ``setup()`` can re-init
+       the same run (for multi-stage workflows like fit then test) or a new
+       run (for multirun sweeps).
+
+    **Compatible Loggers:**
+    - ``WandbLogger`` (online and offline modes)
+
+    ** Ignored Loggers:**
+    - ``TensorBoardLogger``, ``CSVLogger``, ``DummyLogger``, ``None``
+
+    Args:
+        hydra_config: Optional raw Hydra configuration (a dict with keys
+            like ``"trainer"``, ``"module"``, ``"data"``).  Each value
+            should be a ``DictConfig`` or plain ``dict``.  When provided,
+            the config is flattened and uploaded to wandb on the first
+            ``setup()`` call.  When ``None``, the callback skips config
+            sync (useful when the user has already configured wandb
+            externally).  The ``Manager`` injects this automatically.
+
+    Example:
+        .. code-block:: python
+
+            from stable_pretraining.callbacks import WandbCallback
+
+            # With Hydra config (typical Manager usage -- injected automatically):
+            callback = WandbCallback(hydra_config={
+                "trainer": trainer_cfg,
+                "module": module_cfg,
+                "data": data_cfg,
+            })
+            trainer = Trainer(callbacks=[callback], logger=WandbLogger(...))
+            trainer.fit(model, datamodule=dm)
+            # wandb.finish() is called automatically in teardown
+
+            # Without config (manual usage):
+            callback = WandbCallback()
+            trainer = Trainer(callbacks=[callback], logger=WandbLogger(...))
+            trainer.fit(model, datamodule=dm)
+
+    Notes:
+        - For SLURM preemption, pair this with ``WandbCheckpoint`` which
+          persists the wandb run ID inside Lightning checkpoints.
+        - After ``teardown()``, the logger is reset so the next
+          ``setup()`` re-inits the same run with ``resume="allow"``.
+    """
+
+    def __init__(self, hydra_config: Optional[dict] = None):
+        super().__init__()
+        self._hydra_config = hydra_config
+        self._config_synced = False
+        self._run_id: Optional[str] = None
+
+    @rank_zero_only
+    def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+        """Initialize wandb and sync Hydra config.
+
+        Called at the start of fit, validate, test, or predict.  Triggers
+        ``trainer.logger.experiment`` which lazily calls ``wandb.init()``.
+        Then uploads the flattened Hydra config (once per callback lifetime).
+        """
+        if not self._is_wandb(trainer):
+            return
+
+        logging.info(f"WandbCallback: setup for stage='{stage}'")
+
+        # If we have a run ID from a previous teardown, set it so the
+        # logger re-inits the same run (resume="allow").
+        if self._run_id is not None and hasattr(trainer.logger, "_wandb_init"):
+            trainer.logger._wandb_init["id"] = self._run_id
+            trainer.logger._wandb_init["resume"] = "allow"
+            trainer.logger._id = self._run_id
+
+        # Trigger wandb.init() via the logger's lazy property
+        exp = trainer.logger.experiment
+        self._run_id = exp.id
+        logging.info(f"WandbCallback: wandb run active (id={exp.id})")
+
+        # Sync config only once
+        if not self._config_synced:
+            self._sync_config(exp)
+            self._config_synced = True
+
+    @rank_zero_only
+    def teardown(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+        """Dump offline data and close the wandb run.
+
+        Called at the end of fit, validate, test, or predict.  Writes
+        offline summary/config files, then calls ``wandb.finish()`` and
+        resets the logger so a subsequent ``setup()`` can re-init.
+        """
+        if not self._is_wandb(trainer):
+            return
+
+        logging.info(f"WandbCallback: teardown for stage='{stage}'")
+        self._dump_wandb_data()
+
+        if WANDB_AVAILABLE and wandb.run is not None:
+            wandb.finish()
+            logging.info("WandbCallback: wandb.finish() called")
+
+        # Reset the logger so the next setup() triggers a fresh init
+        trainer.logger._experiment = None
+
+    @rank_zero_only
+    def on_exception(
+        self, trainer: Trainer, pl_module: LightningModule, exception: BaseException
+    ) -> None:
+        """Dump offline data on exception for crash recovery."""
+        if not self._is_wandb(trainer):
+            return
+
+        logging.error(
+            f"WandbCallback: exception during training: "
+            f"{type(exception).__name__}: {exception}"
+        )
+        self._dump_wandb_data()
+
+
+    def _sync_config(self, exp) -> None:
+        """Upload Hydra config to wandb, handling offline resume."""
+        if not WANDB_AVAILABLE or wandb.run is None:
+            return
+
+        if exp.offline:
+            self._sync_config_offline(exp)
+        elif len(wandb.config.keys()):
+            logging.info(
+                "WandbCallback: wandb config already populated, "
+                "skipping Hydra config upload"
+            )
+        else:
+            self._sync_config_online()
+
+    def _sync_config_offline(self, exp) -> None:
+        """For offline resume: reload config from previous run directory."""
+        previous_run = self._find_previous_run_dir()
+        if previous_run is None:
+            logging.info("WandbCallback: first offline run, syncing Hydra config")
+            self._sync_config_online()
+            return
+
+        logging.info(
+            f"WandbCallback: found previous offline run ({previous_run}), "
+            f"reusing config"
+        )
+        config_path = previous_run / "files" / "wandb-config.json"
+        with open(config_path, "r") as f:
+            last_config = json.load(f)
+        exp.config.update(last_config)
+        logging.info("WandbCallback: offline config reloaded")
+
+    def _sync_config_online(self) -> None:
+        """Flatten and upload Hydra config to wandb."""
+        if self._hydra_config is None:
+            logging.info("WandbCallback: no Hydra config provided, skipping upload")
+            return
+
+        import pandas as pd
+
+        config = {}
+        for key in ("trainer", "module", "data"):
+            section = self._hydra_config.get(key)
+            if section is None:
+                continue
+            if isinstance(section, (dict, DictConfig)):
+                config[key] = (
+                    OmegaConf.to_container(section, resolve=True)
+                    if isinstance(section, DictConfig)
+                    else section
+                )
+
+        if not config:
+            logging.info(
+                "WandbCallback: everything already instantiated, "
+                "nothing to add to wandb config"
+            )
+            return
+
+        logging.info("WandbCallback: flattening Hydra config for wandb upload")
+        config = pd.json_normalize(config, sep=".").to_dict(orient="records")[0]
+
+        # Iteratively flatten lists into indexed keys
+        while True:
+            all_flat = True
+            for k in list(config.keys()):
+                if isinstance(config[k], list):
+                    all_flat = False
+                    for i, v in enumerate(config[k]):
+                        config[f"{k}.{i}"] = v
+                    del config[k]
+            config = pd.json_normalize(config, sep=".").to_dict(orient="records")[0]
+            if all_flat:
+                break
+
+        logging.info(f"WandbCallback: uploading {len(config)} config items to wandb")
+        if WANDB_AVAILABLE and wandb.run:
+            wandb.config.update(config)
+
+
+    @staticmethod
+    def _dump_wandb_data() -> None:
+        """Write summary and config JSON files for offline runs."""
+
+        if not WANDB_AVAILABLE or wandb.run is None or not wandb.run.offline:
+            return
+
+        run_dir = Path(wandb.run.dir)
+
+        # Dump summary
+        summary_path = run_dir / "wandb-summary.json"
+        if not summary_path.is_file():
+            summary_dict = wandb.run.summary._as_dict()
+            logging.info(f"WandbCallback: summary: {json.dumps(summary_dict, indent=2)}")
+            with open(summary_path, "w") as f:
+                json.dump(summary_dict, f)
+            logging.info(f"WandbCallback: saved summary at {summary_path}")
+        else:
+            logging.debug("WandbCallback: summary file already exists, skipping")
+
+        # Dump config
+        config_path = run_dir / "wandb-config.json"
+        if not config_path.is_file():
+            with open(config_path, "w") as f:
+                json.dump(wandb.run.config.as_dict(), f)
+            logging.info(f"WandbCallback: saved config at {config_path}")
+        else:
+            logging.debug("WandbCallback: config file already exists, skipping")
+
+    @staticmethod
+    def _find_previous_run_dir() -> Optional[Path]:
+        """Find the previous offline run directory for config reuse.
+
+        When a SLURM job is requeued and the wandb run ID is preserved
+        (via ``WandbCheckpoint``), the same run ID produces multiple
+        ``offline-run-*-<id>`` directories.  This method returns the
+        second-to-last one (the previous run).
+
+        Returns:
+            Path to the previous run directory, or ``None`` if this is
+            the first run or wandb is not running offline.
+        """
+        if not WANDB_AVAILABLE or not wandb.run:
+            return None
+
+        current_dir = Path(wandb.run.dir).parent
+        parent = current_dir.parent
+        logging.info(f"WandbCallback: searching for previous offline runs in {parent}")
+
+        runs = sorted(parent.glob(f"offline-run-*-{wandb.run.id}"))
+        logging.info(f"WandbCallback: found {len(runs)} run(s)")
+        for run in runs:
+            logging.debug(f"WandbCallback:   - {run.name}")
+
+        if len(runs) <= 1:
+            return None
+
+        assert runs[-1] == current_dir, (
+            f"Expected current dir {current_dir} to be the last run, "
+            f"but got {runs[-1]}"
+        )
+        return runs[-2]
+
+
+    @staticmethod
+    def _is_wandb(trainer: Trainer) -> bool:
+        """Check if the trainer uses a WandbLogger."""
+        return isinstance(trainer.logger, WandbLogger)
+
+
+class WandbCheckpoint(Callback):
+    """Persist the wandb run ID inside Lightning checkpoints.
+
+    This callback ensures wandb run continuity across SLURM preemption
+    and requeue cycles.  On checkpoint save, it stores the current wandb
+    run ID.  On checkpoint load, it detects a mismatch between the active
+    run and the checkpoint's run, and re-initializes wandb with the
+    correct run ID so that metrics continue to be logged to the same run.
+
+    This callback is automatically included in the default callback list
+    via ``callbacks.factories.default()``.  It works in tandem with
+    ``WandbCallback`` which handles the broader wandb lifecycle.
+
+    Notes:
+        - No-op when the trainer does not use ``WandbLogger``.
+        - On load, if the run IDs already match, no re-initialization
+          is performed.
+        - On load with a mismatched ID, the current (incorrect) wandb
+          run is deleted via the wandb API and a new run is created with
+          the checkpoint's ID.
+    """
+
+    def setup(
+        self, trainer: Trainer, pl_module: LightningModule, stage: Optional[str] = None
+    ) -> None:
+        logging.info("WandbCheckpoint: setup")
+
+    def on_save_checkpoint(self, trainer, pl_module, checkpoint):
+        logging.info("WandbCheckpoint: saving wandb run ID to checkpoint")
+        if isinstance(trainer.logger, WandbLogger):
+            checkpoint["wandb"] = {"id": trainer.logger.version}
+            logging.info(f"WandbCheckpoint: saved run ID={trainer.logger.version}")
+
+    def on_load_checkpoint(self, trainer, pl_module, checkpoint):
+        logging.info("WandbCheckpoint: checking for wandb run ID in checkpoint")
+        if "wandb" not in checkpoint:
+            return
+
+        logging.info("WandbCheckpoint: found wandb info, restoring run continuity")
+        if not hasattr(trainer, "logger"):
+            logging.warning("WandbCheckpoint: trainer has no logger, skipping")
+            return
+        if not isinstance(trainer.logger, WandbLogger):
+            logging.warning(
+                f"WandbCheckpoint: expected WandbLogger, got {trainer.logger}, skipping"
+            )
+            return
+
+        logging.info("WandbCheckpoint: trainer has a WandbLogger")
+        import wandb as _wandb
+
+        if _wandb.run is None and trainer.global_rank > 0:
+            logging.info(
+                "WandbCheckpoint: run not initialized on non-zero rank, skipping"
+            )
+            return
+
+        if _wandb.run is not None and _wandb.run.id == checkpoint["wandb"]["id"]:
+            logging.info("WandbCheckpoint: run ID already matches checkpoint, skipping")
+            return
+
+        # Run ID mismatch: delete the incorrect run and re-init with correct ID
+        logging.info(
+            f"WandbCheckpoint: deleting mismatched run "
+            f"{_wandb.run.entity}/{_wandb.run.project}/{_wandb.run.id}"
+        )
+        api = _wandb.Api()
+        run = api.run(f"{_wandb.run.entity}/{_wandb.run.project}/{_wandb.run.id}")
+        _wandb.finish()
+        run.delete()
+        trainer.logger._experiment = None
+        wandb_id = checkpoint["wandb"]["id"]
+        trainer.logger._wandb_init["id"] = wandb_id
+        trainer.logger._id = wandb_id
+        # Trigger re-init
+        trainer.logger.experiment
+        logging.info(
+            f"WandbCheckpoint: re-initialized run "
+            f"{_wandb.run.entity}/{_wandb.run.project}/{_wandb.run.id}"
+        )

--- a/stable_pretraining/callbacks/wandb_lifecycle.py
+++ b/stable_pretraining/callbacks/wandb_lifecycle.py
@@ -19,7 +19,7 @@ else:
 class WandbCallback(Callback):
     """Manage the wandb run lifecycle: init, config sync, and teardown.
 
-    This callback consolidates wandb-specific logic. 
+    This callback consolidates wandb-specific logic.
     It handles the following concerns:
 
     1. **Run initialization** -- On ``setup()``, triggers ``wandb.init()``
@@ -58,11 +58,13 @@ class WandbCallback(Callback):
             from stable_pretraining.callbacks import WandbCallback
 
             # With Hydra config (typical Manager usage -- injected automatically):
-            callback = WandbCallback(hydra_config={
-                "trainer": trainer_cfg,
-                "module": module_cfg,
-                "data": data_cfg,
-            })
+            callback = WandbCallback(
+                hydra_config={
+                    "trainer": trainer_cfg,
+                    "module": module_cfg,
+                    "data": data_cfg,
+                }
+            )
             trainer = Trainer(callbacks=[callback], logger=WandbLogger(...))
             trainer.fit(model, datamodule=dm)
             # wandb.finish() is called automatically in teardown
@@ -116,7 +118,9 @@ class WandbCallback(Callback):
             self._config_synced = True
 
     @rank_zero_only
-    def teardown(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+    def teardown(
+        self, trainer: Trainer, pl_module: LightningModule, stage: str
+    ) -> None:
         """Dump offline data and close the wandb run.
 
         Called at the end of fit, validate, test, or predict.  Writes
@@ -149,7 +153,6 @@ class WandbCallback(Callback):
             f"{type(exception).__name__}: {exception}"
         )
         self._dump_wandb_data()
-
 
     def _sync_config(self, exp) -> None:
         """Upload Hydra config to wandb, handling offline resume."""
@@ -231,11 +234,9 @@ class WandbCallback(Callback):
         if WANDB_AVAILABLE and wandb.run:
             wandb.config.update(config)
 
-
     @staticmethod
     def _dump_wandb_data() -> None:
         """Write summary and config JSON files for offline runs."""
-
         if not WANDB_AVAILABLE or wandb.run is None or not wandb.run.offline:
             return
 
@@ -245,7 +246,9 @@ class WandbCallback(Callback):
         summary_path = run_dir / "wandb-summary.json"
         if not summary_path.is_file():
             summary_dict = wandb.run.summary._as_dict()
-            logging.info(f"WandbCallback: summary: {json.dumps(summary_dict, indent=2)}")
+            logging.info(
+                f"WandbCallback: summary: {json.dumps(summary_dict, indent=2)}"
+            )
             with open(summary_path, "w") as f:
                 json.dump(summary_dict, f)
             logging.info(f"WandbCallback: saved summary at {summary_path}")
@@ -290,11 +293,9 @@ class WandbCallback(Callback):
             return None
 
         assert runs[-1] == current_dir, (
-            f"Expected current dir {current_dir} to be the last run, "
-            f"but got {runs[-1]}"
+            f"Expected current dir {current_dir} to be the last run, but got {runs[-1]}"
         )
         return runs[-2]
-
 
     @staticmethod
     def _is_wandb(trainer: Trainer) -> bool:

--- a/stable_pretraining/tests/unit/test_wandb_lifecycle.py
+++ b/stable_pretraining/tests/unit/test_wandb_lifecycle.py
@@ -12,7 +12,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import pytest
 from omegaconf import OmegaConf
 
 from stable_pretraining.callbacks.wandb_lifecycle import WandbCallback, WandbCheckpoint
@@ -90,21 +89,27 @@ class TestConfigFlattening:
         mock_wandb.config.update = capture_update
 
         hydra_cfg = {
-            "trainer": OmegaConf.create({
-                "max_epochs": 100,
-                "accelerator": "gpu",
-            }),
-            "module": OmegaConf.create({
-                "backbone": {"type": "resnet", "depth": 18},
-                "loss": {"name": "cross_entropy"},
-            }),
+            "trainer": OmegaConf.create(
+                {
+                    "max_epochs": 100,
+                    "accelerator": "gpu",
+                }
+            ),
+            "module": OmegaConf.create(
+                {
+                    "backbone": {"type": "resnet", "depth": 18},
+                    "loss": {"name": "cross_entropy"},
+                }
+            ),
         }
         callback = WandbCallback(hydra_config=hydra_cfg)
         callback._sync_config_online()
 
         # Every value should be a scalar (no nested dicts or lists)
         for k, v in captured.items():
-            assert not isinstance(v, (dict, list)), f"Key '{k}' has non-scalar value: {v}"
+            assert not isinstance(v, (dict, list)), (
+                f"Key '{k}' has non-scalar value: {v}"
+            )
             assert "." in k or k in ("trainer.max_epochs", "trainer.accelerator"), (
                 f"Key '{k}' should be dot-separated"
             )
@@ -123,10 +128,12 @@ class TestConfigFlattening:
         mock_wandb.config.update = lambda d: captured.update(d)
 
         hydra_cfg = {
-            "module": OmegaConf.create({
-                "layers": [64, 128, 256],
-                "name": "test",
-            }),
+            "module": OmegaConf.create(
+                {
+                    "layers": [64, 128, 256],
+                    "name": "test",
+                }
+            ),
         }
         callback = WandbCallback(hydra_config=hydra_cfg)
         callback._sync_config_online()

--- a/stable_pretraining/tests/unit/test_wandb_lifecycle.py
+++ b/stable_pretraining/tests/unit/test_wandb_lifecycle.py
@@ -1,0 +1,385 @@
+"""Tests for WandbCallback and WandbCheckpoint.
+
+Tests verify: config flattening, offline file I/O,
+run directory discovery, and logger state management.
+
+Run with:
+    pytest stable_pretraining/tests/unit/test_wandb_lifecycle.py -v
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from omegaconf import OmegaConf
+
+from stable_pretraining.callbacks.wandb_lifecycle import WandbCallback, WandbCheckpoint
+
+
+def _make_trainer(logger=None):
+    """Build a minimal Trainer-like object with the given logger."""
+    trainer = MagicMock()
+    trainer.logger = logger
+    trainer.callbacks = []
+    trainer.global_rank = 0
+    return trainer
+
+
+def _make_wandb_logger(version="run123", wandb_init=None):
+    """Build a minimal WandbLogger-like object."""
+    from lightning.pytorch.loggers import WandbLogger
+
+    logger = MagicMock(spec=WandbLogger)
+    logger.version = version
+    logger._wandb_init = wandb_init or {}
+    logger._experiment = MagicMock()
+    logger._id = version
+    # .experiment returns an object with .id and .offline
+    exp = MagicMock()
+    exp.id = version
+    exp.offline = False
+    type(logger).experiment = PropertyMock(return_value=exp)
+    return logger
+
+
+class TestWandbCallbackNoopWithoutWandB:
+    """WandbCallback is a no-op when the trainer has no WandbLogger."""
+
+    def test_noop_with_csv_logger(self):
+        from lightning.pytorch.loggers import CSVLogger
+
+        callback = WandbCallback()
+        trainer = _make_trainer(logger=MagicMock(spec=CSVLogger))
+        module = MagicMock()
+
+        # Should not raise
+        callback.setup(trainer, module, stage="fit")
+        callback.teardown(trainer, module, stage="fit")
+
+        # Internal state should be untouched
+        assert callback._run_id is None
+        assert not callback._config_synced
+
+    def test_noop_with_none_logger(self):
+        callback = WandbCallback()
+        trainer = _make_trainer(logger=None)
+        module = MagicMock()
+
+        callback.setup(trainer, module, stage="fit")
+        callback.teardown(trainer, module, stage="fit")
+
+        assert callback._run_id is None
+
+
+class TestConfigFlattening:
+    """_sync_config_online flattens nested OmegaConf into dot-separated keys."""
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_nested_dicts_flattened(self, mock_wandb):
+        mock_wandb.run = MagicMock()
+        mock_wandb.config = MagicMock()
+        mock_wandb.config.keys.return_value = []  # empty config triggers upload
+
+        captured = {}
+
+        def capture_update(d):
+            captured.update(d)
+
+        mock_wandb.config.update = capture_update
+
+        hydra_cfg = {
+            "trainer": OmegaConf.create({
+                "max_epochs": 100,
+                "accelerator": "gpu",
+            }),
+            "module": OmegaConf.create({
+                "backbone": {"type": "resnet", "depth": 18},
+                "loss": {"name": "cross_entropy"},
+            }),
+        }
+        callback = WandbCallback(hydra_config=hydra_cfg)
+        callback._sync_config_online()
+
+        # Every value should be a scalar (no nested dicts or lists)
+        for k, v in captured.items():
+            assert not isinstance(v, (dict, list)), f"Key '{k}' has non-scalar value: {v}"
+            assert "." in k or k in ("trainer.max_epochs", "trainer.accelerator"), (
+                f"Key '{k}' should be dot-separated"
+            )
+
+        assert captured["trainer.max_epochs"] == 100
+        assert captured["module.backbone.type"] == "resnet"
+        assert captured["module.backbone.depth"] == 18
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_lists_expanded_to_indexed_keys(self, mock_wandb):
+        mock_wandb.run = MagicMock()
+        mock_wandb.config = MagicMock()
+        mock_wandb.config.keys.return_value = []
+
+        captured = {}
+        mock_wandb.config.update = lambda d: captured.update(d)
+
+        hydra_cfg = {
+            "module": OmegaConf.create({
+                "layers": [64, 128, 256],
+                "name": "test",
+            }),
+        }
+        callback = WandbCallback(hydra_config=hydra_cfg)
+        callback._sync_config_online()
+
+        assert captured["module.layers.0"] == 64
+        assert captured["module.layers.1"] == 128
+        assert captured["module.layers.2"] == 256
+        assert captured["module.name"] == "test"
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_no_config_skips_upload(self, mock_wandb):
+        mock_wandb.run = MagicMock()
+        mock_wandb.config = MagicMock()
+        mock_wandb.config.keys.return_value = []
+        mock_wandb.config.update = MagicMock()
+
+        callback = WandbCallback(hydra_config=None)
+        callback._sync_config_online()
+
+        mock_wandb.config.update.assert_not_called()
+
+
+class TestOfflineDataDump:
+    """_dump_wandb_data writes real JSON files for offline runs."""
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_writes_summary_and_config(self, mock_wandb):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.offline = True
+            mock_wandb.run.dir = tmpdir
+            mock_wandb.run.summary._as_dict.return_value = {
+                "train/loss": 0.42,
+                "epoch": 10,
+            }
+            mock_wandb.run.config.as_dict.return_value = {
+                "lr": 0.001,
+                "model": "resnet18",
+            }
+
+            WandbCallback._dump_wandb_data()
+
+            summary_path = Path(tmpdir) / "wandb-summary.json"
+            config_path = Path(tmpdir) / "wandb-config.json"
+
+            assert summary_path.is_file()
+            assert config_path.is_file()
+
+            with open(summary_path) as f:
+                summary = json.load(f)
+            assert summary["train/loss"] == 0.42
+            assert summary["epoch"] == 10
+
+            with open(config_path) as f:
+                config = json.load(f)
+            assert config["lr"] == 0.001
+            assert config["model"] == "resnet18"
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_idempotent_skips_existing(self, mock_wandb):
+        """Calling _dump_wandb_data twice doesn't overwrite or raise."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.offline = True
+            mock_wandb.run.dir = tmpdir
+            mock_wandb.run.summary._as_dict.return_value = {"loss": 1.0}
+            mock_wandb.run.config.as_dict.return_value = {"lr": 0.01}
+
+            WandbCallback._dump_wandb_data()
+
+            # Read first write
+            with open(Path(tmpdir) / "wandb-summary.json") as f:
+                first_summary = json.load(f)
+
+            # Change the mock return — if dump overwrites, content would differ
+            mock_wandb.run.summary._as_dict.return_value = {"loss": 999.0}
+
+            WandbCallback._dump_wandb_data()  # should be a no-op
+
+            with open(Path(tmpdir) / "wandb-summary.json") as f:
+                second_summary = json.load(f)
+
+            assert first_summary == second_summary
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_skips_online_runs(self, mock_wandb):
+        """No files written for online runs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.offline = False
+            mock_wandb.run.dir = tmpdir
+
+            WandbCallback._dump_wandb_data()
+
+            assert not (Path(tmpdir) / "wandb-summary.json").exists()
+            assert not (Path(tmpdir) / "wandb-config.json").exists()
+
+
+class TestFindPreviousRunDir:
+    """_find_previous_run_dir uses real directory structure."""
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_finds_previous_dir(self, mock_wandb):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_id = "abc123"
+            dir1 = Path(tmpdir) / f"offline-run-20250101-{run_id}"
+            dir2 = Path(tmpdir) / f"offline-run-20250102-{run_id}"
+            dir1.mkdir()
+            dir2.mkdir()
+
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.id = run_id
+            # wandb.run.dir points to <run_dir>/files
+            mock_wandb.run.dir = str(dir2 / "files")
+
+            result = WandbCallback._find_previous_run_dir()
+            assert result == dir1
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_returns_none_for_first_run(self, mock_wandb):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_id = "abc123"
+            dir1 = Path(tmpdir) / f"offline-run-20250101-{run_id}"
+            dir1.mkdir()
+
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.id = run_id
+            mock_wandb.run.dir = str(dir1 / "files")
+
+            result = WandbCallback._find_previous_run_dir()
+            assert result is None
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_ignores_unrelated_dirs(self, mock_wandb):
+        """Only dirs matching the current run ID are considered."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_id = "abc123"
+            other_id = "xyz789"
+            dir_mine = Path(tmpdir) / f"offline-run-20250101-{run_id}"
+            dir_other = Path(tmpdir) / f"offline-run-20250102-{other_id}"
+            dir_mine.mkdir()
+            dir_other.mkdir()
+
+            mock_wandb.run = MagicMock()
+            mock_wandb.run.id = run_id
+            mock_wandb.run.dir = str(dir_mine / "files")
+
+            result = WandbCallback._find_previous_run_dir()
+            assert result is None  # only one dir for this run ID
+
+
+class TestSetupCapturesRunId:
+    """setup() captures the wandb run ID from the experiment."""
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.WANDB_AVAILABLE", True)
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_run_id_captured(self, mock_wandb):
+        mock_wandb.run = MagicMock()
+        mock_wandb.config = MagicMock()
+        mock_wandb.config.keys.return_value = ["existing_key"]
+
+        logger = _make_wandb_logger(version="test456")
+        trainer = _make_trainer(logger=logger)
+        module = MagicMock()
+
+        callback = WandbCallback()
+        callback.setup(trainer, module, stage="fit")
+
+        assert callback._run_id == "test456"
+
+
+class TestTeardownResetsLogger:
+    """teardown() calls wandb.finish() and resets the logger."""
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.WANDB_AVAILABLE", True)
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_logger_experiment_reset(self, mock_wandb):
+        mock_wandb.run = MagicMock()
+        mock_wandb.run.offline = False
+
+        logger = _make_wandb_logger(version="run789")
+        trainer = _make_trainer(logger=logger)
+        module = MagicMock()
+
+        callback = WandbCallback()
+        callback.teardown(trainer, module, stage="fit")
+
+        mock_wandb.finish.assert_called_once()
+        assert trainer.logger._experiment is None
+
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.WANDB_AVAILABLE", True)
+    @patch("stable_pretraining.callbacks.wandb_lifecycle.wandb")
+    def test_setup_after_teardown_sets_resume(self, mock_wandb):
+        """After teardown, next setup() sets resume='allow' with saved run ID."""
+        mock_wandb.run = MagicMock()
+        mock_wandb.run.offline = False
+        mock_wandb.config = MagicMock()
+        mock_wandb.config.keys.return_value = ["key"]
+
+        logger = _make_wandb_logger(version="run_abc")
+        logger._wandb_init = {"project": "test"}
+        trainer = _make_trainer(logger=logger)
+        module = MagicMock()
+
+        callback = WandbCallback()
+
+        # First setup captures run ID
+        callback.setup(trainer, module, stage="fit")
+        assert callback._run_id == "run_abc"
+
+        # Teardown resets logger
+        callback.teardown(trainer, module, stage="fit")
+        assert trainer.logger._experiment is None
+
+        # Second setup should set resume="allow" and the saved run ID
+        callback.setup(trainer, module, stage="validate")
+        assert trainer.logger._wandb_init["id"] == "run_abc"
+        assert trainer.logger._wandb_init["resume"] == "allow"
+
+
+class TestWandbCheckpointSave:
+    """WandbCheckpoint saves the run ID into the checkpoint dict."""
+
+    def test_saves_run_id(self):
+        logger = _make_wandb_logger(version="run_save_test")
+        trainer = _make_trainer(logger=logger)
+        module = MagicMock()
+        checkpoint = {}
+
+        cb = WandbCheckpoint()
+        cb.on_save_checkpoint(trainer, module, checkpoint)
+
+        assert "wandb" in checkpoint
+        assert checkpoint["wandb"]["id"] == "run_save_test"
+
+    def test_noop_without_wandb_logger(self):
+        from lightning.pytorch.loggers import CSVLogger
+
+        trainer = _make_trainer(logger=MagicMock(spec=CSVLogger))
+        module = MagicMock()
+        checkpoint = {}
+
+        cb = WandbCheckpoint()
+        cb.on_save_checkpoint(trainer, module, checkpoint)
+
+        assert "wandb" not in checkpoint
+
+    def test_noop_with_none_logger(self):
+        trainer = _make_trainer(logger=None)
+        module = MagicMock()
+        checkpoint = {}
+
+        cb = WandbCheckpoint()
+        cb.on_save_checkpoint(trainer, module, checkpoint)
+
+        assert "wandb" not in checkpoint


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->
Extracts all wandb lifecycle logic (init, config sync, offline data dump, wandb.finish()) from Manager into a new WandbCallback that uses Lightning's setup()/teardown() hooks, so wandb.finish() is called automatically after each trainer stage. This fixes run leaks in multirun sweeps (fit then test) without requiring manual cleanup

Moves WandbCheckpoint out of checkpoint_sklearn.py into wandb_lifecycle.py alongside WandbCallback, and fixes its docstring which was copy-pasted from the sklearn checkpoint

Adds unit tests covering config flattening, offline file I/O, SLURM requeue directory discovery, setup/teardown state management, on_exception crash recovery, and checkpoint run-ID continuity

## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
