### PR TITLE
[Feature] give SubSet access to dataset attr/methods

### DIFF
--- a/stable_pretraining/data/datasets.py
+++ b/stable_pretraining/data/datasets.py
@@ -49,6 +49,11 @@ class Dataset(torch.utils.data.Dataset):
 class Subset(Dataset):
     r"""Subset of a dataset at specified indices.
 
+    All attributes and methods of the wrapped dataset are accessible directly
+    on the subset via attribute proxying. For example, if the underlying dataset
+    has a ``column_names`` property or a ``custom_method()``, they can be called
+    as ``subset.column_names`` or ``subset.custom_method()`` respectively.
+
     Args:
         dataset (Dataset): The whole Dataset
         indices (sequence): Indices in the whole set selected for subset
@@ -78,9 +83,12 @@ class Subset(Dataset):
     def __len__(self):
         return len(self.indices)
 
-    @property
-    def column_names(self):
-        return self.dataset.column_names
+    def __getattr__(self, name):
+        if (
+            name == "dataset"
+        ):  # avoid infinite recursion when dataset attribute is not set
+            raise AttributeError("dataset")
+        return getattr(self.dataset, name)
 
 
 class FromTorchDataset(Dataset):

--- a/stable_pretraining/tests/unit/test_datasets.py
+++ b/stable_pretraining/tests/unit/test_datasets.py
@@ -364,3 +364,96 @@ class TestDatasetUnit:
                 # Verify custom storage_options was used
                 call_kwargs = mock_load_dataset.call_args[1]
                 assert call_kwargs["storage_options"] == custom_storage
+
+    def test_subset_proxies_attribute_to_dataset(self):
+        """Test that Subset.__getattr__ delegates unknown attributes to the wrapped dataset."""
+        from stable_pretraining.data.datasets import Dataset, Subset
+
+        class CustomDataset(Dataset):
+            column_names = ["a", "b"]
+            custom_attr = 42
+
+            def __getitem__(self, idx):
+                return {"a": idx, "b": idx * 2}
+
+            def __len__(self):
+                return 10
+
+        ds = CustomDataset()
+        subset = Subset(ds, [0, 1, 2])
+
+        assert subset.column_names == ["a", "b"]
+        assert subset.custom_attr == 42
+
+    def test_subset_proxies_method_to_dataset(self):
+        """Test that Subset.__getattr__ delegates method calls to the wrapped dataset."""
+        from stable_pretraining.data.datasets import Dataset, Subset
+
+        class CustomDataset(Dataset):
+            def __getitem__(self, idx):
+                return {"x": idx}
+
+            def __len__(self):
+                return 5
+
+            def custom_method(self, val):
+                return val * 3
+
+        ds = CustomDataset()
+        subset = Subset(ds, [0, 1])
+
+        assert subset.custom_method(4) == 12
+
+    def test_subset_own_attributes_not_proxied(self):
+        """Test that Subset's own attributes (dataset, indices, transform) are not proxied."""
+        from stable_pretraining.data.datasets import Dataset, Subset
+
+        class CustomDataset(Dataset):
+            indices = "should_not_see_this"
+
+            def __getitem__(self, idx):
+                return {"x": idx}
+
+            def __len__(self):
+                return 5
+
+        ds = CustomDataset()
+        indices = [0, 1, 2]
+        subset = Subset(ds, indices)
+
+        # subset.indices should be the actual indices list, not the dataset's attribute
+        assert subset.indices is indices
+
+    def test_subset_missing_attribute_raises(self):
+        """Test that accessing a truly missing attribute raises AttributeError."""
+        from stable_pretraining.data.datasets import Dataset, Subset
+
+        class CustomDataset(Dataset):
+            def __getitem__(self, idx):
+                return {"x": idx}
+
+            def __len__(self):
+                return 5
+
+        ds = CustomDataset()
+        subset = Subset(ds, [0, 1])
+
+        with pytest.raises(AttributeError):
+            _ = subset.does_not_exist_anywhere
+
+    def test_subset_getattr_before_dataset_set(self):
+        """Test that __getattr__ does not recurse infinitely when self.dataset has not yet been set.
+
+        As happens during unpickling in DataLoader workers.
+        """
+        from stable_pretraining.data.datasets import Subset
+
+        # Simulate the state right after __new__ but before __init__ restores
+        # instance attributes (i.e. an empty __dict__).
+        subset = object.__new__(Subset)
+        # self.dataset is not in __dict__ yet — accessing it must raise
+        # AttributeError cleanly rather than infinite recursion.
+        with pytest.raises(AttributeError):
+            _ = subset.dataset
+        with pytest.raises(AttributeError):
+            _ = subset.column_names


### PR DESCRIPTION
This pull request enhances the `Subset` dataset wrapper by enabling attribute and method proxying to the underlying dataset, and adds comprehensive tests to ensure correct proxying behavior and error handling. The main improvement is that `Subset` now transparently exposes all properties and methods of the wrapped dataset, making it easier to use in place of the original dataset.

Enhancements to `Subset` proxying:

* Added documentation to `Subset` explaining that all attributes and methods of the wrapped dataset are accessible directly on the subset via attribute proxying. (`stable_pretraining/data/datasets.py`)
* Implemented `__getattr__` in `Subset` to delegate attribute access to the wrapped dataset, except for its own attributes, preventing infinite recursion. (`stable_pretraining/data/datasets.py`)

Testing improvements:

* Added unit tests to verify that `Subset` correctly proxies attributes and methods, does not proxy its own attributes, raises `AttributeError` for missing attributes, and handles cases where the dataset attribute is not yet set (e.g., during unpickling). (`stable_pretraining/tests/unit/test_datasets.py`)