### PR TITLE
[Fix] Support FSDP named_parameters signature

### DIFF
--- a/stable_pretraining/module.py
+++ b/stable_pretraining/module.py
@@ -139,7 +139,11 @@ class Module(pl.LightningModule):
         raise NotImplementedError("The forward() method must be implemented.")
 
     def named_parameters(
-        self, with_callbacks=True, prefix: str = "", recurse: bool = True
+        self,
+        with_callbacks=True,
+        prefix: str = "",
+        recurse: bool = True,
+        remove_duplicate: bool = True,
     ):
         """Override to globally exclude callback-related parameters.
 
@@ -152,6 +156,8 @@ class Module(pl.LightningModule):
             prefix (str, optional): Prefix to prepend to parameter names. Defaults to "".
             recurse (bool, optional): If True, yields parameters of this module and all submodules.
                 If False, yields only direct parameters. Defaults to True.
+            remove_duplicate (bool, optional): Forwarded to ``torch.nn.Module.named_parameters``.
+                Defaults to True.
 
         Yields:
             tuple[str, torch.nn.Parameter]: Name and parameter pairs.
@@ -162,7 +168,11 @@ class Module(pl.LightningModule):
                 "You are calling self.parameters which also gives callbacks "
                 "parameters, to remove then, pass `with_callbacks=False`"
             )
-        for name, param in super().named_parameters(prefix=prefix, recurse=recurse):
+        for name, param in super().named_parameters(
+            prefix=prefix,
+            recurse=recurse,
+            remove_duplicate=remove_duplicate,
+        ):
             is_callback = name.startswith("callbacks_")
             if is_callback and not with_callbacks:
                 continue

--- a/stable_pretraining/tests/unit/test_module.py
+++ b/stable_pretraining/tests/unit/test_module.py
@@ -28,6 +28,30 @@ def test_module_initialization():
     assert module is not None
 
 
+@pytest.mark.unit
+def test_named_parameters_accepts_remove_duplicate():
+    """Module.named_parameters should preserve the modern nn.Module API."""
+    shared = nn.Linear(1, 1)
+
+    module = Module(
+        backbone=shared,
+        projector=shared,
+        forward=forward.simclr_forward,
+        simclr_loss=NTXEntLoss(temperature=0.5),
+        optim={
+            "optimizer": {"type": "Adam", "lr": 0.001},
+            "scheduler": {"type": "CosineAnnealing"},
+            "interval": "epoch",
+        },
+    )
+
+    deduped = list(module.named_parameters(remove_duplicate=True))
+    duplicated = list(module.named_parameters(remove_duplicate=False))
+
+    assert deduped
+    assert len(duplicated) > len(deduped)
+
+
 @pytest.mark.integration
 def test_module_integration():
     """Integration test for the Module class with multiple optimizers.


### PR DESCRIPTION
## Summary
- add `remove_duplicate` to `Module.named_parameters`
- forward the argument to `torch.nn.Module.named_parameters`
- add a regression test covering the modern `named_parameters(remove_duplicate=...)` API

## Why
`stable_pretraining.Module` overrides `named_parameters`, but the override was missing the modern `remove_duplicate` argument from PyTorch.

This breaks FSDP setup in downstream projects, because FSDP calls:
`module.named_parameters(remove_duplicate=...)`

With the old override, that raises:
`TypeError: Module.named_parameters() got an unexpected keyword argument 'remove_duplicate'`

## Test plan
- [x] pre-commit
- [x] `python -m py_compile stable_pretraining/module.py stable_pretraining/tests/unit/test_module.py`
- [x] braid smoke test instantiating `Module` and calling:
  - `named_parameters(remove_duplicate=True)`
  - `named_parameters(remove_duplicate=False)`