### PR TITLE
[BugFix] Fix CLIPLoss targets shape in distributed training and missing return in all_gather. Co-authored with @qhua360

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -15,3 +15,4 @@ Version 0.1
 - RankMe, LiDAR metrics to monitor training.
 - Examples of extracting run data from WandB and utilizing it to create figures.
 - Fixed a bug in the logging functionality.
+- Fixed CLIPLoss targets shape in distributed training and missing return in ``all_gather``.

--- a/examples/supervised_learning.py
+++ b/examples/supervised_learning.py
@@ -1,5 +1,4 @@
-"""
-Supervised Learning Example
+"""Supervised Learning Example
 ============================
 
 This example demonstrates how to train models using supervised learning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "richuru",
     "opt-einsum",
-    "tqdm",
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "richuru",
     "opt-einsum",
+    "tqdm",
 ]
 
 dynamic = ["version"]

--- a/stable_pretraining/_config.py
+++ b/stable_pretraining/_config.py
@@ -81,9 +81,7 @@ class _GlobalConfig:
         _default_cache = str(
             os.path.join(os.path.expanduser("~"), ".cache", "stable-pretraining")
         )
-        self._cache_dir: Optional[str] = os.environ.get(
-            "SPT_CACHE_DIR", _default_cache
-        )
+        self._cache_dir: Optional[str] = os.environ.get("SPT_CACHE_DIR", _default_cache)
         self._requeue_checkpoint: bool = True
 
     # -- verbose ---------------------------------------------------------------
@@ -214,9 +212,7 @@ class _GlobalConfig:
 
     @default_loggers.setter
     def default_loggers(self, value: Dict[str, bool]) -> None:
-        _VALID_LOGGER_KEYS = (
-            "registry",
-        )
+        _VALID_LOGGER_KEYS = ("registry",)
         if not isinstance(value, dict):
             raise TypeError(
                 f"default_loggers must be a dict, got {type(value).__name__}"

--- a/stable_pretraining/cli.py
+++ b/stable_pretraining/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Command-line interface for Stable SSL training."""
 
+import os
 import sys
 from pathlib import Path
 import subprocess
@@ -242,7 +243,9 @@ def _open_registry(db_path: Optional[str]):
 def registry_ls(
     tag: Optional[str] = typer.Option(None, help="Filter by tag"),
     status: Optional[str] = typer.Option(None, help="Filter by status"),
-    sort: Optional[str] = typer.Option(None, "--sort", help="Sort by column or summary.<key>"),
+    sort: Optional[str] = typer.Option(
+        None, "--sort", help="Sort by column or summary.<key>"
+    ),
     limit: Optional[int] = typer.Option(None, "-n", help="Max rows"),
     db: Optional[str] = typer.Option(None, "--db", help="Path to registry.db"),
 ):
@@ -348,12 +351,14 @@ def best(
         val = r.summary.get(metric, "N/A")
         if isinstance(val, float):
             val = f"{val:.6f}"
-        rows.append({
-            "run_id": r.run_id,
-            metric: val,
-            "tags": ", ".join(r.tags) if r.tags else "",
-            "run_dir": r.run_dir or "",
-        })
+        rows.append(
+            {
+                "run_id": r.run_id,
+                metric: val,
+                "tags": ", ".join(r.tags) if r.tags else "",
+                "run_dir": r.run_dir or "",
+            }
+        )
 
     import pandas as pd
 
@@ -364,7 +369,9 @@ def best(
 
 @registry_app.command()
 def export(
-    output: str = typer.Argument("runs.csv", help="Output file path (.csv or .parquet)"),
+    output: str = typer.Argument(
+        "runs.csv", help="Output file path (.csv or .parquet)"
+    ),
     tag: Optional[str] = typer.Option(None, help="Filter by tag"),
     status: Optional[str] = typer.Option(None, help="Filter by status"),
     db: Optional[str] = typer.Option(None, "--db", help="Path to registry.db"),
@@ -415,19 +422,25 @@ def status(
     db: Optional[str] = typer.Option(None, "--db", help="Path to registry.db"),
 ):
     """Check if the registry server is running."""
-    from stable_pretraining.registry._db import _read_discovery, _server_is_alive, _default_db_path
+    from stable_pretraining.registry._db import (
+        _read_discovery,
+        _server_is_alive,
+        _default_db_path,
+    )
 
     db_path = db or _default_db_path()
     info = _read_discovery(db_path)
     if info and _server_is_alive(info["url"]):
         typer.echo(f"✓ Running at {info['url']} (pid {info.get('pid', '?')})")
     elif info:
-        typer.echo(f"✗ Discovery file exists but server at {info['url']} is not responding.")
-        typer.echo(f"  Run: spt registry ensure")
+        typer.echo(
+            f"✗ Discovery file exists but server at {info['url']} is not responding."
+        )
+        typer.echo("  Run: spt registry ensure")
         raise typer.Exit(code=1)
     else:
         typer.echo(f"✗ No server found (no discovery file at {db_path}).")
-        typer.echo(f"  Run: spt registry ensure")
+        typer.echo("  Run: spt registry ensure")
         raise typer.Exit(code=1)
 
 
@@ -438,7 +451,11 @@ def stop(
     """Stop the registry server."""
     import signal
 
-    from stable_pretraining.registry._db import _read_discovery, _discovery_path, _default_db_path
+    from stable_pretraining.registry._db import (
+        _read_discovery,
+        _discovery_path,
+        _default_db_path,
+    )
 
     db_path = db or _default_db_path()
     info = _read_discovery(db_path)
@@ -466,7 +483,9 @@ def stop(
 
 @registry_app.command()
 def sync(
-    scan_dir: Optional[str] = typer.Argument(None, help="Directory to scan (default: cache_dir)"),
+    scan_dir: Optional[str] = typer.Argument(
+        None, help="Directory to scan (default: cache_dir)"
+    ),
     db: Optional[str] = typer.Option(None, "--db", help="Path to registry.db"),
 ):
     """Sync sidecar files from interrupted runs into the registry.
@@ -488,15 +507,19 @@ def sync(
     # Determine scan root
     if scan_dir is None:
         import os
+
         scan_dir = os.environ.get("SPT_CACHE_DIR")
         if scan_dir is None:
             try:
                 from stable_pretraining._config import get_config
+
                 scan_dir = get_config().cache_dir
             except Exception:
                 pass
         if scan_dir is None:
-            typer.echo("Error: No scan directory. Pass a path or set SPT_CACHE_DIR.", err=True)
+            typer.echo(
+                "Error: No scan directory. Pass a path or set SPT_CACHE_DIR.", err=True
+            )
             raise typer.Exit(code=1)
 
     import json

--- a/stable_pretraining/losses/joint_embedding.py
+++ b/stable_pretraining/losses/joint_embedding.py
@@ -107,7 +107,9 @@ class BarlowTwinsLoss(torch.nn.Module):
         Returns:
             float: The computed loss.
         """
-        c = self._normalize(z_i).T @ self._normalize(z_j)  # normalize along the batch dimension
+        c = self._normalize(z_i).T @ self._normalize(
+            z_j
+        )  # normalize along the batch dimension
         c = c / z_i.size(0)
         all_reduce(c)
 

--- a/stable_pretraining/losses/multimodal.py
+++ b/stable_pretraining/losses/multimodal.py
@@ -31,10 +31,13 @@ class CLIPLoss(InfoNCELoss):
         feats_j: torch.Tensor,
         logit_scale: Optional[torch.Tensor | float] = None,
     ) -> torch.Tensor:
-        # for CLIP, targets are always the diagonal
-        targets = torch.arange(feats_i.size(0), device=feats_i.device)
-        if torch.distributed.is_initialized():
-            targets = targets + torch.distributed.get_rank() * feats_i.size(0)
+        # _compute all_gathers both sides -> logits [world*B, world*B]; targets must be length world*B.
+        b = feats_i.size(0)
+        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+            w = torch.distributed.get_world_size()
+            targets = torch.arange(w * b, device=feats_i.device, dtype=torch.long)
+        else:
+            targets = torch.arange(b, device=feats_i.device, dtype=torch.long)
 
         # calculate loss in both directions
         loss_i = self._compute(

--- a/stable_pretraining/losses/multimodal.py
+++ b/stable_pretraining/losses/multimodal.py
@@ -33,7 +33,10 @@ class CLIPLoss(InfoNCELoss):
     ) -> torch.Tensor:
         # _compute all_gathers both sides -> logits [world*B, world*B]; targets must be length world*B.
         b = feats_i.size(0)
-        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+        if (
+            torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        ):
             w = torch.distributed.get_world_size()
             targets = torch.arange(w * b, device=feats_i.device, dtype=torch.long)
         else:

--- a/stable_pretraining/losses/multimodal.py
+++ b/stable_pretraining/losses/multimodal.py
@@ -33,6 +33,8 @@ class CLIPLoss(InfoNCELoss):
     ) -> torch.Tensor:
         # for CLIP, targets are always the diagonal
         targets = torch.arange(feats_i.size(0), device=feats_i.device)
+        if torch.distributed.is_initialized():
+            targets = targets + torch.distributed.get_rank() * feats_i.size(0)
 
         # calculate loss in both directions
         loss_i = self._compute(

--- a/stable_pretraining/registry/_client.py
+++ b/stable_pretraining/registry/_client.py
@@ -116,11 +116,19 @@ class RegistryClient:
         tags: Optional[List[str]] = None,
         notes: Optional[str] = None,
     ) -> None:
-        self._request("POST", "/runs", body={
-            "run_id": run_id, "status": status, "run_dir": run_dir,
-            "config": config or {}, "hparams": hparams or {},
-            "tags": tags or [], "notes": notes or "",
-        })
+        self._request(
+            "POST",
+            "/runs",
+            body={
+                "run_id": run_id,
+                "status": status,
+                "run_dir": run_dir,
+                "config": config or {},
+                "hparams": hparams or {},
+                "tags": tags or [],
+                "notes": notes or "",
+            },
+        )
 
     def update_run(self, run_id: str, **fields: Any) -> None:
         if not fields:

--- a/stable_pretraining/registry/_db.py
+++ b/stable_pretraining/registry/_db.py
@@ -25,14 +25,12 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Union
-
-from loguru import logger as logging
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -60,7 +58,9 @@ def _default_db_path() -> str:
     """Resolve the default registry.db path from config or env."""
     cache_dir = os.environ.get("SPT_CACHE_DIR")
     if cache_dir is None:
-        cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "stable-pretraining")
+        cache_dir = os.path.join(
+            os.path.expanduser("~"), ".cache", "stable-pretraining"
+        )
     return str(Path(cache_dir).resolve() / "registry.db")
 
 
@@ -99,6 +99,7 @@ def _write_discovery(db_path: str, info: dict) -> None:
 # ensure_server — called from CLI / .bashrc
 # ---------------------------------------------------------------------------
 
+
 def ensure_server(db_path: str | None = None) -> str:
     """Ensure a registry server is running.  Start one if not.
 
@@ -122,9 +123,12 @@ def ensure_server(db_path: str | None = None) -> str:
 
     server_script = str(Path(__file__).parent / "_server.py")
     cmd = [
-        sys.executable, server_script,
-        "--db", str(Path(db_path).resolve()),
-        "--port", str(port),
+        sys.executable,
+        server_script,
+        "--db",
+        str(Path(db_path).resolve()),
+        "--port",
+        str(port),
     ]
 
     log_file = Path(db_path).with_suffix(".server.log")
@@ -145,20 +149,21 @@ def ensure_server(db_path: str | None = None) -> str:
     deadline = time.time() + 15.0
     while time.time() < deadline:
         if _server_is_alive(url):
-            _write_discovery(db_path, {
-                "url": url,
-                "pid": pid,
-                "port": port,
-                "hostname": hostname,
-                "db_path": str(Path(db_path).resolve()),
-                "started_at": time.time(),
-            })
+            _write_discovery(
+                db_path,
+                {
+                    "url": url,
+                    "pid": pid,
+                    "port": port,
+                    "hostname": hostname,
+                    "db_path": str(Path(db_path).resolve()),
+                    "started_at": time.time(),
+                },
+            )
             return url
         time.sleep(0.3)
 
-    raise RuntimeError(
-        f"Registry server did not start within 15s. Check {log_file}"
-    )
+    raise RuntimeError(f"Registry server did not start within 15s. Check {log_file}")
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +180,7 @@ Add this to your ~/.bashrc (run once on the login node):
 Then re-open your shell or run it manually."""
 
 
-def RegistryDB(db_path: str) -> "RegistryClient":  # noqa: N802
+def RegistryDB(db_path: str) -> "RegistryClient":  # noqa: N802, F821
     """Connect to the registry server for *db_path*.
 
     The server must already be running (started via

--- a/stable_pretraining/registry/_local.py
+++ b/stable_pretraining/registry/_local.py
@@ -184,10 +184,10 @@ class LocalRegistryDB:
         order = ""
         if sort_by is not None:
             if sort_by.startswith("summary."):
-                key = sort_by[len("summary."):]
+                key = sort_by[len("summary.") :]
                 col_expr = f"json_extract(summary, '$.{key}')"
             elif sort_by.startswith("hparams."):
-                key = sort_by[len("hparams."):]
+                key = sort_by[len("hparams.") :]
                 col_expr = f"json_extract(hparams, '$.{key}')"
             else:
                 col_expr = sort_by

--- a/stable_pretraining/registry/_server.py
+++ b/stable_pretraining/registry/_server.py
@@ -51,8 +51,11 @@ class _ServerDB:
         self._check_and_repair()
 
     def _check_and_repair(self) -> None:
-        """Verify DB integrity on startup.  If corrupt (e.g. stale NFS
-        WAL), remove the file and let SQLite recreate it."""
+        """Verify DB integrity on startup.
+
+        If corrupt (e.g. stale NFS WAL), remove the file and let SQLite
+        recreate it.
+        """
         p = Path(self.db_path)
         if not p.exists():
             return
@@ -63,9 +66,11 @@ class _ServerDB:
             conn.close()
         except (sqlite3.DatabaseError, sqlite3.OperationalError) as exc:
             import sys
+
             print(
                 f"[spt-registry] DB corrupt ({exc}), removing and starting fresh.",
-                file=sys.stderr, flush=True,
+                file=sys.stderr,
+                flush=True,
             )
             for suffix in ("", "-wal", "-shm"):
                 try:
@@ -100,8 +105,17 @@ class _ServerDB:
                     raise
         raise sqlite3.OperationalError("max retries")  # pragma: no cover
 
-    def insert_run(self, run_id, *, status="running", run_dir=None,
-                   config=None, hparams=None, tags=None, notes=None):
+    def insert_run(
+        self,
+        run_id,
+        *,
+        status="running",
+        run_dir=None,
+        config=None,
+        hparams=None,
+        tags=None,
+        notes=None,
+    ):
         now = time.time()
         self._exec(
             "INSERT INTO runs "
@@ -112,9 +126,18 @@ class _ServerDB:
             "run_dir=excluded.run_dir,config=excluded.config,"
             "hparams=excluded.hparams,summary=excluded.summary,"
             "tags=excluded.tags,notes=excluded.notes",
-            (run_id, status, now, now, run_dir,
-             json.dumps(config or {}), json.dumps(hparams or {}),
-             json.dumps({}), json.dumps(tags or []), notes or ""),
+            (
+                run_id,
+                status,
+                now,
+                now,
+                run_dir,
+                json.dumps(config or {}),
+                json.dumps(hparams or {}),
+                json.dumps({}),
+                json.dumps(tags or []),
+                notes or "",
+            ),
         )
 
     def update_run(self, run_id: str, **fields):
@@ -136,18 +159,23 @@ class _ServerDB:
         self._exec(f"UPDATE runs SET {clause} WHERE run_id = ?", vals)
 
     def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
-        row = self._conn().execute(
-            "SELECT * FROM runs WHERE run_id = ?", (run_id,)
-        ).fetchone()
+        row = (
+            self._conn()
+            .execute("SELECT * FROM runs WHERE run_id = ?", (run_id,))
+            .fetchone()
+        )
         return _to_dict(row) if row else None
 
-    def query_runs(self, *, status=None, tag=None, sort_by=None,
-                   descending=True, limit=None) -> List[Dict[str, Any]]:
+    def query_runs(
+        self, *, status=None, tag=None, sort_by=None, descending=True, limit=None
+    ) -> List[Dict[str, Any]]:
         clauses, params = [], []
         if status:
-            clauses.append("status = ?"); params.append(status)
+            clauses.append("status = ?")
+            params.append(status)
         if tag:
-            clauses.append("tags LIKE ?"); params.append(f'%"{tag}"%')
+            clauses.append("tags LIKE ?")
+            params.append(f'%"{tag}"%')
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
         order = ""
         if sort_by:
@@ -159,9 +187,11 @@ class _ServerDB:
                 col = sort_by
             order = f" ORDER BY {col} {'DESC' if descending else 'ASC'}"
         lim = f" LIMIT {int(limit)}" if limit else ""
-        rows = self._conn().execute(
-            f"SELECT * FROM runs{where}{order}{lim}", tuple(params)
-        ).fetchall()
+        rows = (
+            self._conn()
+            .execute(f"SELECT * FROM runs{where}{order}{lim}", tuple(params))
+            .fetchall()
+        )
         return [_to_dict(r) for r in rows]
 
     def count(self) -> int:
@@ -172,11 +202,15 @@ def _to_dict(row: sqlite3.Row) -> Dict[str, Any]:
     d = dict(row)
     for col in ("config", "hparams", "summary"):
         if isinstance(d.get(col), str):
-            try: d[col] = json.loads(d[col])
-            except (json.JSONDecodeError, TypeError): d[col] = {}
+            try:
+                d[col] = json.loads(d[col])
+            except (json.JSONDecodeError, TypeError):
+                d[col] = {}
     if isinstance(d.get("tags"), str):
-        try: d["tags"] = json.loads(d["tags"])
-        except (json.JSONDecodeError, TypeError): d["tags"] = []
+        try:
+            d["tags"] = json.loads(d["tags"])
+        except (json.JSONDecodeError, TypeError):
+            d["tags"] = []
     return d
 
 
@@ -184,7 +218,8 @@ def _to_dict(row: sqlite3.Row) -> Dict[str, Any]:
 # FastAPI app
 # ---------------------------------------------------------------------------
 
-def create_app(db_path: str) -> "FastAPI":
+
+def create_app(db_path: str) -> "FastAPI":  # noqa: F821
     from fastapi import FastAPI, HTTPException
     from pydantic import BaseModel as _BaseModel
 
@@ -221,11 +256,18 @@ def create_app(db_path: str) -> "FastAPI":
     @app.post("/api/runs", status_code=201)
     def create_run(run: RunCreate):
         try:
-            db.insert_run(run.run_id, status=run.status, run_dir=run.run_dir,
-                          config=run.config, hparams=run.hparams,
-                          tags=run.tags, notes=run.notes)
+            db.insert_run(
+                run.run_id,
+                status=run.status,
+                run_dir=run.run_dir,
+                config=run.config,
+                hparams=run.hparams,
+                tags=run.tags,
+                notes=run.notes,
+            )
         except Exception as exc:
             import traceback
+
             detail = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
             raise HTTPException(500, detail=detail)
         return {"run_id": run.run_id}
@@ -239,6 +281,7 @@ def create_app(db_path: str) -> "FastAPI":
             db.update_run(run_id, **fields)
         except Exception as exc:
             import traceback
+
             detail = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
             raise HTTPException(500, detail=detail)
         return {"run_id": run_id}
@@ -255,11 +298,16 @@ def create_app(db_path: str) -> "FastAPI":
         return run
 
     @app.get("/api/runs")
-    def list_runs(status: Optional[str] = None, tag: Optional[str] = None,
-                  sort_by: Optional[str] = None, descending: bool = True,
-                  limit: Optional[int] = None):
-        return db.query_runs(status=status, tag=tag, sort_by=sort_by,
-                             descending=descending, limit=limit)
+    def list_runs(
+        status: Optional[str] = None,
+        tag: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        descending: bool = True,
+        limit: Optional[int] = None,
+    ):
+        return db.query_runs(
+            status=status, tag=tag, sort_by=sort_by, descending=descending, limit=limit
+        )
 
     return app
 
@@ -267,6 +315,7 @@ def create_app(db_path: str) -> "FastAPI":
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -276,8 +325,14 @@ def main():
     args = parser.parse_args()
 
     import uvicorn
-    uvicorn.run(create_app(args.db), host=args.host, port=args.port,
-                workers=1, log_level="warning")
+
+    uvicorn.run(
+        create_app(args.db),
+        host=args.host,
+        port=args.port,
+        workers=1,
+        log_level="warning",
+    )
 
 
 if __name__ == "__main__":

--- a/stable_pretraining/registry/logger.py
+++ b/stable_pretraining/registry/logger.py
@@ -100,23 +100,29 @@ class RegistryLogger(Logger):
     # -- resilient DB calls ----------------------------------------------------
 
     def _safe_db_call(self, fn, *args, **kwargs) -> bool:
-        """Call a DB method.  On failure (server died during preemption),
-        save a sidecar JSON file in the run directory so data can be
-        recovered later with ``spt registry sync``.
+        """Call a DB method.
 
-        Returns True on success, False on failure."""
+        On failure (server died during preemption), save a sidecar JSON file
+        in the run directory so data can be recovered later with
+        ``spt registry sync``.
+
+        Returns True on success, False on failure.
+        """
         try:
             fn(*args, **kwargs)
             return True
         except Exception as exc:
             from loguru import logger as _log
+
             _log.warning(f"! Registry server unreachable ({exc}), writing sidecar.")
             self._write_sidecar()
             return False
 
     def _write_sidecar(self) -> None:
-        """Write the current run state as a JSON sidecar file in the
-        run directory.  ``spt registry sync`` picks these up later."""
+        """Write the current run state as a JSON sidecar file in the run directory.
+
+        ``spt registry sync`` picks these up later.
+        """
         if self._run_dir is None or self._run_id is None:
             return
         try:
@@ -133,7 +139,10 @@ class RegistryLogger(Logger):
                 "tags": list(self._tags),
                 "notes": self._notes,
             }
-            import json, tempfile, os
+            import json
+            import tempfile
+            import os
+
             fd, tmp = tempfile.mkstemp(dir=str(sidecar_dir), suffix=".tmp")
             try:
                 with os.fdopen(fd, "w") as f:
@@ -188,9 +197,7 @@ class RegistryLogger(Logger):
             return
 
         # Map Lightning status strings
-        db_status = {"success": "completed", "failed": "failed"}.get(
-            status, status
-        )
+        db_status = {"success": "completed", "failed": "failed"}.get(status, status)
 
         # Find best checkpoint path if available
         checkpoint_path = self._find_checkpoint()
@@ -281,7 +288,9 @@ def _flatten_params(params: Any) -> dict[str, Any]:
 
     if not isinstance(params, dict):
         # Namespace or other object
-        params = vars(params) if hasattr(params, "__dict__") else {"params": str(params)}
+        params = (
+            vars(params) if hasattr(params, "__dict__") else {"params": str(params)}
+        )
 
     flat: dict[str, Any] = {}
     _flatten(params, "", flat)

--- a/stable_pretraining/registry/query.py
+++ b/stable_pretraining/registry/query.py
@@ -14,8 +14,8 @@ Example::
 
     # Best runs by validation accuracy
     best = reg.query(tag="sweep:12345", sort_by="summary.val_acc", limit=5)
-    print(best[0].summary)       # {"val_acc": 0.847, ...}
-    print(best[0].run_dir)       # /scratch/runs/runs/20260408/.../12345_0/
+    print(best[0].summary)  # {"val_acc": 0.847, ...}
+    print(best[0].run_dir)  # /scratch/runs/runs/20260408/.../12345_0/
     print(best[0].checkpoint_path)
 
     # Export to pandas DataFrame

--- a/stable_pretraining/tests/regression/_capture_refs.py
+++ b/stable_pretraining/tests/regression/_capture_refs.py
@@ -22,22 +22,29 @@ EMBED_DIM, PROJ_DIM, NUM_CLASSES, IMAGE_SIZE = 64, 32, 10, 32
 
 def make_backbone():
     return nn.Sequential(
-        nn.Conv2d(3, 16, 3, padding=1), nn.ReLU(),
-        nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(16, EMBED_DIM),
+        nn.Conv2d(3, 16, 3, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool2d(1),
+        nn.Flatten(),
+        nn.Linear(16, EMBED_DIM),
     )
 
 
 def make_projector():
     return nn.Sequential(
-        nn.Linear(EMBED_DIM, EMBED_DIM), nn.BatchNorm1d(EMBED_DIM),
-        nn.ReLU(), nn.Linear(EMBED_DIM, PROJ_DIM),
+        nn.Linear(EMBED_DIM, EMBED_DIM),
+        nn.BatchNorm1d(EMBED_DIM),
+        nn.ReLU(),
+        nn.Linear(EMBED_DIM, PROJ_DIM),
     )
 
 
 def make_predictor():
     return nn.Sequential(
-        nn.Linear(PROJ_DIM, PROJ_DIM), nn.BatchNorm1d(PROJ_DIM),
-        nn.ReLU(), nn.Linear(PROJ_DIM, PROJ_DIM),
+        nn.Linear(PROJ_DIM, PROJ_DIM),
+        nn.BatchNorm1d(PROJ_DIM),
+        nn.ReLU(),
+        nn.Linear(PROJ_DIM, PROJ_DIM),
     )
 
 
@@ -56,55 +63,89 @@ class FakeDataset(Dataset):
 
     def __getitem__(self, i):
         if self.multi_view:
-            return {"views": [
-                {"image": self.images[i] + self.n1[i], "label": self.labels[i]},
-                {"image": self.images[i] + self.n2[i], "label": self.labels[i]},
-            ]}
+            return {
+                "views": [
+                    {"image": self.images[i] + self.n1[i], "label": self.labels[i]},
+                    {"image": self.images[i] + self.n2[i], "label": self.labels[i]},
+                ]
+            }
         return {"image": self.images[i], "label": self.labels[i]}
 
 
 def make_data(multi_view=True):
     return spt.data.DataModule(
-        train=DataLoader(FakeDataset(32, multi_view), batch_size=8, drop_last=True, num_workers=0),
+        train=DataLoader(
+            FakeDataset(32, multi_view), batch_size=8, drop_last=True, num_workers=0
+        ),
         val=DataLoader(FakeDataset(16, False), batch_size=8, num_workers=0),
     )
 
 
 METHODS = {
     "simclr": lambda: dict(
-        module=spt.Module(backbone=make_backbone(), projector=make_projector(),
-            forward=forward.simclr_forward, simclr_loss=losses.NTXEntLoss(temperature=0.5),
-            optim={"optimizer": {"type": "Adam", "lr": 1e-3}}),
-        data=make_data(True)),
+        module=spt.Module(
+            backbone=make_backbone(),
+            projector=make_projector(),
+            forward=forward.simclr_forward,
+            simclr_loss=losses.NTXEntLoss(temperature=0.5),
+            optim={"optimizer": {"type": "Adam", "lr": 1e-3}},
+        ),
+        data=make_data(True),
+    ),
     "byol": lambda: dict(
-        module=spt.Module(backbone=spt.backbone.TeacherStudentWrapper(make_backbone()),
+        module=spt.Module(
+            backbone=spt.backbone.TeacherStudentWrapper(make_backbone()),
             projector=spt.backbone.TeacherStudentWrapper(make_projector()),
-            predictor=make_predictor(), forward=forward.byol_forward,
+            predictor=make_predictor(),
+            forward=forward.byol_forward,
             byol_loss=losses.BYOLLoss(),
-            optim={"optimizer": {"type": "Adam", "lr": 1e-3}}),
-        data=make_data(True)),
+            optim={"optimizer": {"type": "Adam", "lr": 1e-3}},
+        ),
+        data=make_data(True),
+    ),
     "vicreg": lambda: dict(
-        module=spt.Module(backbone=make_backbone(), projector=make_projector(),
-            forward=forward.vicreg_forward, vicreg_loss=losses.VICRegLoss(),
-            optim={"optimizer": {"type": "Adam", "lr": 1e-3}}),
-        data=make_data(True)),
+        module=spt.Module(
+            backbone=make_backbone(),
+            projector=make_projector(),
+            forward=forward.vicreg_forward,
+            vicreg_loss=losses.VICRegLoss(),
+            optim={"optimizer": {"type": "Adam", "lr": 1e-3}},
+        ),
+        data=make_data(True),
+    ),
     "barlow_twins": lambda: dict(
-        module=spt.Module(backbone=make_backbone(), projector=make_projector(),
-            forward=forward.barlow_twins_forward, barlow_loss=losses.BarlowTwinsLoss(),
-            optim={"optimizer": {"type": "Adam", "lr": 1e-3}}),
-        data=make_data(True)),
+        module=spt.Module(
+            backbone=make_backbone(),
+            projector=make_projector(),
+            forward=forward.barlow_twins_forward,
+            barlow_loss=losses.BarlowTwinsLoss(),
+            optim={"optimizer": {"type": "Adam", "lr": 1e-3}},
+        ),
+        data=make_data(True),
+    ),
     "supervised": lambda: dict(
-        module=spt.Module(backbone=make_backbone(), classifier=nn.Linear(EMBED_DIM, NUM_CLASSES),
-            forward=forward.supervised_forward, supervised_loss=nn.CrossEntropyLoss(),
-            optim={"optimizer": {"type": "Adam", "lr": 1e-3}}),
-        data=make_data(False)),
+        module=spt.Module(
+            backbone=make_backbone(),
+            classifier=nn.Linear(EMBED_DIM, NUM_CLASSES),
+            forward=forward.supervised_forward,
+            supervised_loss=nn.CrossEntropyLoss(),
+            optim={"optimizer": {"type": "Adam", "lr": 1e-3}},
+        ),
+        data=make_data(False),
+    ),
 }
 
-trainer_cfg = OmegaConf.create({
-    "_target_": "lightning.Trainer", "max_epochs": 1, "accelerator": "cpu",
-    "enable_checkpointing": False, "enable_progress_bar": False,
-    "enable_model_summary": False, "num_sanity_val_steps": 0,
-})
+trainer_cfg = OmegaConf.create(
+    {
+        "_target_": "lightning.Trainer",
+        "max_epochs": 1,
+        "accelerator": "cpu",
+        "enable_checkpointing": False,
+        "enable_progress_bar": False,
+        "enable_model_summary": False,
+        "num_sanity_val_steps": 0,
+    }
+)
 
 
 if __name__ == "__main__":

--- a/stable_pretraining/tests/regression/test_methods.py
+++ b/stable_pretraining/tests/regression/test_methods.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.regression
 # Fake dataset (no downloads, CPU-only)
 # ---------------------------------------------------------------------------
 
+
 class FakeDataset(Dataset):
     """Returns dicts with an image and label.
 
@@ -56,10 +57,14 @@ class FakeDataset(Dataset):
             # Mimics MultiViewTransform output: dict with "views" key
             return {
                 "views": [
-                    {"image": self.images[idx] + self.noise1[idx],
-                     "label": self.labels[idx]},
-                    {"image": self.images[idx] + self.noise2[idx],
-                     "label": self.labels[idx]},
+                    {
+                        "image": self.images[idx] + self.noise1[idx],
+                        "label": self.labels[idx],
+                    },
+                    {
+                        "image": self.images[idx] + self.noise2[idx],
+                        "label": self.labels[idx],
+                    },
                 ]
             }
         return {"image": self.images[idx], "label": self.labels[idx]}
@@ -105,28 +110,38 @@ def make_predictor(in_dim=PROJ_DIM, out_dim=PROJ_DIM):
 
 
 def make_data(multi_view=True):
-    ds = FakeDataset(num_samples=32, image_size=IMAGE_SIZE, num_classes=NUM_CLASSES, multi_view=multi_view)
+    ds = FakeDataset(
+        num_samples=32,
+        image_size=IMAGE_SIZE,
+        num_classes=NUM_CLASSES,
+        multi_view=multi_view,
+    )
     train_dl = DataLoader(ds, batch_size=8, drop_last=True, num_workers=0)
-    val_ds = FakeDataset(num_samples=16, image_size=IMAGE_SIZE, num_classes=NUM_CLASSES, multi_view=False)
+    val_ds = FakeDataset(
+        num_samples=16, image_size=IMAGE_SIZE, num_classes=NUM_CLASSES, multi_view=False
+    )
     val_dl = DataLoader(val_ds, batch_size=8, num_workers=0)
     return spt.data.DataModule(train=train_dl, val=val_dl)
 
 
 def make_trainer_cfg():
-    return OmegaConf.create({
-        "_target_": "lightning.Trainer",
-        "max_epochs": 1,
-        "accelerator": "cpu",
-        "enable_checkpointing": False,
-        "enable_progress_bar": False,
-        "enable_model_summary": False,
-        "num_sanity_val_steps": 0,
-    })
+    return OmegaConf.create(
+        {
+            "_target_": "lightning.Trainer",
+            "max_epochs": 1,
+            "accelerator": "cpu",
+            "enable_checkpointing": False,
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "num_sanity_val_steps": 0,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # Method definitions
 # ---------------------------------------------------------------------------
+
 
 def build_simclr():
     return dict(
@@ -224,6 +239,7 @@ REFERENCE_LOSSES = {
 def test_method_trains_and_registers(method_name, tmp_path):
     """Each SSL method completes 1 epoch and is indexed in the registry."""
     import lightning as pl
+
     pl.seed_everything(42, workers=True)
     builder = METHOD_BUILDERS[method_name]
     components = builder()
@@ -238,6 +254,7 @@ def test_method_trains_and_registers(method_name, tmp_path):
 
     # Verify the run is in the registry
     from stable_pretraining._config import get_config
+
     db_path = str(get_config().cache_dir) + "/registry.db"
     reg = Registry(RegistryDB(db_path))
 
@@ -263,6 +280,7 @@ def test_method_matches_reference(method_name, tmp_path):
         python stable_pretraining/tests/regression/_capture_refs.py
     """
     import lightning as pl
+
     pl.seed_everything(42, workers=True)
 
     builder = METHOD_BUILDERS[method_name]
@@ -278,6 +296,7 @@ def test_method_matches_reference(method_name, tmp_path):
     manager()
 
     from stable_pretraining._config import get_config
+
     db_path = str(get_config().cache_dir) + "/registry.db"
     reg = Registry(RegistryDB(db_path))
     runs = reg.query(status="completed")

--- a/stable_pretraining/tests/unit/test_cache_dir.py
+++ b/stable_pretraining/tests/unit/test_cache_dir.py
@@ -50,6 +50,8 @@ def cache_dir(tmp_path):
 
 
 class TestCacheDirConfig:
+    """Tests for cache_dir configuration."""
+
     def test_default_is_set(self, monkeypatch):
         monkeypatch.delenv("SPT_CACHE_DIR", raising=False)
         get_config().reset()
@@ -119,6 +121,8 @@ class TestCacheDirConfig:
 
 
 class TestRequeueCheckpointConfig:
+    """Tests for requeue_checkpoint configuration."""
+
     def test_default_is_true(self):
         assert get_config().requeue_checkpoint is True
 
@@ -164,6 +168,8 @@ class TestRequeueCheckpointConfig:
 
 
 class TestGenerateRunId:
+    """Tests for run ID generation."""
+
     def test_uuid_fallback(self, monkeypatch):
         monkeypatch.delenv("SLURM_JOB_ID", raising=False)
         monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
@@ -216,6 +222,8 @@ class TestGenerateRunId:
 
 
 class TestResolveRunDir:
+    """Tests for run directory resolution."""
+
     def _make_manager(self, ckpt_path=None):
         return Manager(
             trainer=BoringTrainer(enable_checkpointing=False, logger=False),
@@ -353,6 +361,8 @@ class TestResolveRunDir:
 
 
 class TestInjectRunDir:
+    """Tests for run directory injection into configs."""
+
     def test_injects_into_dictconfig(self, tmp_path):
         cfg = OmegaConf.create(
             {
@@ -409,6 +419,8 @@ class TestInjectRunDir:
 
 
 class TestResolveLoadPath:
+    """Tests for checkpoint load path resolution."""
+
     def test_returns_user_ckpt_path_when_exists(self, tmp_path):
         """User's explicit ckpt_path is used for loading."""
         user_ckpt = tmp_path / "pretrained.ckpt"
@@ -509,6 +521,8 @@ class TestResolveLoadPath:
 
 
 class TestConfigureCacheDirCheckpointing:
+    """Tests for cache directory checkpointing configuration."""
+
     def _make_manager_with_trainer(self, tmp_path):
         """Create a Manager with an instantiated trainer and run_dir."""
         trainer = BoringTrainer(
@@ -668,6 +682,8 @@ class TestConfigureCacheDirCheckpointing:
 
 
 class TestRunDirCallback:
+    """Tests for the _RunDirCallback."""
+
     def test_persists_run_dir_in_checkpoint(self):
         cb = _RunDirCallback("/some/path")
         checkpoint = {}
@@ -687,6 +703,8 @@ class TestRunDirCallback:
 
 
 class TestHydraConflictWarnings:
+    """Tests for Hydra conflict warning behavior."""
+
     def test_no_crash_without_hydra(self):
         Manager._warn_hydra_conflicts()
 
@@ -697,6 +715,8 @@ class TestHydraConflictWarnings:
 
 
 class TestSaveCheckpointWithRunDir:
+    """Tests for checkpoint saving with run directory."""
+
     def test_default_path_uses_run_dir(self, tmp_path):
         trainer = BoringTrainer(
             default_root_dir=str(tmp_path),
@@ -755,6 +775,8 @@ class TestSaveCheckpointWithRunDir:
 
 
 class TestManagerCallWithCacheDir:
+    """Tests for Manager.__call__() with cache directory."""
+
     def test_full_flow_with_config_trainer(self, cache_dir, monkeypatch):
         """Manager.__call__() creates run_dir, injects into trainer, sets up checkpointing."""
         monkeypatch.delenv("SLURM_JOB_ID", raising=False)
@@ -938,6 +960,7 @@ class TestManagerCallWithCacheDir:
 
     def test_requeue_loads_from_run_dir_not_ckpt_path(self, cache_dir, monkeypatch):
         """Simulate requeue: run_dir has last.ckpt, no user ckpt_path.
+
         The fit call should receive the auto-detected checkpoint.
         """
         monkeypatch.delenv("SLURM_JOB_ID", raising=False)
@@ -993,6 +1016,7 @@ class TestManagerCallWithCacheDir:
 
     def test_slurm_requeue_no_ckpt_path_auto_loads(self, cache_dir, monkeypatch):
         """SLURM requeue: no ckpt_path, same SLURM_JOB_ID.
+
         Should find prev run_dir by job ID and auto-load last.ckpt.
         """
         monkeypatch.setenv("SLURM_JOB_ID", "88888")
@@ -1097,6 +1121,8 @@ class TestManagerCallWithCacheDir:
 
 
 class TestCallbackPathResolution:
+    """Tests for callback path resolution with run directory."""
+
     def test_hf_checkpoint_resolves_relative_save_dir(self):
         try:
             from stable_pretraining.callbacks.hf_models import (
@@ -1147,6 +1173,8 @@ class TestCallbackPathResolution:
 
 
 class TestNoCollisions:
+    """Tests for run directory collision avoidance."""
+
     def test_two_managers_get_different_run_dirs(self, cache_dir, monkeypatch):
         monkeypatch.delenv("SLURM_JOB_ID", raising=False)
         monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)

--- a/stable_pretraining/utils/distributed.py
+++ b/stable_pretraining/utils/distributed.py
@@ -26,7 +26,7 @@ def all_gather(tensor, *args, **kwargs):
         Tuple containing the gathered tensors
     """
     if is_dist_avail_and_initialized():
-        torch.distributed.nn.functional.all_gather(tensor, *args, **kwargs)
+        return torch.distributed.nn.functional.all_gather(tensor, *args, **kwargs)
     return (tensor,)
 
 


### PR DESCRIPTION
## Description

Fixes two bugs affecting distributed (DDP) training:

1. **`CLIPLoss` wrong targets under distributed training** (`losses/multimodal.py`):
   `_compute` all-gathers both sides, producing logits of shape `[world*B, world*B]`,
   but targets were always `arange(B)` instead of `arange(world*B)`. This caused a
   shape mismatch and incorrect loss values when running on multiple GPUs.

2. **`all_gather` silently dropped its return value** (`utils/distributed.py`):
   Missing `return` on the `torch.distributed.nn.functional.all_gather` call meant
   the function always returned the single-process fallback `(tensor,)` even in
   distributed mode.

**Validation:** Ran CLIP (RN50, bs512, lr0.002) under DDP before and after the fix,
and verified against a manual reference implementation. It was trained on CC3M over 40 epochs:
- `clip_rn50_20260408_132830` — pre-fix (buggy): plateaus at ~0.36 top-1
- `clip_rn50_20260410_014650` — post-fix: reaches ~0.42 top-1, matches manual impl
- `clip_rn50_20260409_132200` — manual reference impl ([OpenCLIP](https://github.com/mlfoundations/open_clip)): tracks post-fix run exactly: tracks post-fix run exactly

The pre-fix run shows clearly degraded performance, confirming the bug had a real
impact on training. Performance after the fix aligns with expected results from Table 2 of
[Sobal et al. (2024)](https://arxiv.org/abs/2407.18134).

<table>
  <tr>
    <td><img width="432" alt="linprobe/imagenet1k/top1" src="https://github.com/user-attachments/assets/3ca5e5c1-b422-4560-8abc-604747eba01a" /></td>
    <td><img width="432" alt="linprobe/imagenet1k/top5" src="https://github.com/user-attachments/assets/c4876d5c-d11e-4c1c-91c2-4c05c13f6549" /></td>
  </tr>
</table>

## Checklist

- [x] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.