### PR TITLE
EnvironmentDumpCallback: drop _dump_thread when pickled

### DIFF
--- a/stable_pretraining/callbacks/env_info.py
+++ b/stable_pretraining/callbacks/env_info.py
@@ -44,6 +44,21 @@ class EnvironmentDumpCallback(Callback):
             f"  EnvironmentDumpCallback initialized (filename={filename}, async={async_dump})"
         )
 
+    def __getstate__(self):
+        """Return picklable state.
+
+        ``threading.Thread`` holds a ``_thread.lock`` (``_tstate_lock``)
+        which is not picklable. Drop ``_dump_thread`` so spawn-mode
+        DataLoader workers can serialise this callback when it is
+        reachable from the trainer/module graph (see issue #416).
+
+        The dump thread is fire-and-forget on the main process only; the
+        worker side has no use for the handle.
+        """
+        state = self.__dict__.copy()
+        state["_dump_thread"] = None
+        return state
+
     @rank_zero_only
     def setup(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule, stage: str

--- a/stable_pretraining/tests/unit/test_env_callback.py
+++ b/stable_pretraining/tests/unit/test_env_callback.py
@@ -872,6 +872,45 @@ class TestErrorHandling:
                 if callback:
                     del callback
 
+    def test_callback_picklable_after_thread_started(
+        self, dummy_model, temp_log_dir, mock_subprocess_success
+    ):
+        """Regression test for issue #416.
+
+        Spawn-mode DataLoader workers must be able to pickle the
+        trainer/module graph that contains this callback.
+        ``threading.Thread`` holds a ``_thread.lock``, so the callback
+        must drop ``_dump_thread`` in ``__getstate__``.
+        """
+        import pickle
+
+        callback = EnvironmentDumpCallback(async_dump=True)
+        trainer = None
+
+        try:
+            trainer = Trainer(
+                default_root_dir=temp_log_dir,
+                callbacks=[callback],
+                logger=False,
+                enable_checkpointing=False,
+            )
+
+            callback.setup(trainer, dummy_model, stage="fit")
+            assert callback._dump_thread is not None
+
+            blob = pickle.dumps(callback)
+            restored = pickle.loads(blob)
+            assert restored._dump_thread is None
+            assert restored.filename == callback.filename
+            assert restored.async_dump == callback.async_dump
+        finally:
+            if callback._dump_thread and callback._dump_thread.is_alive():
+                callback._dump_thread.join(timeout=5)
+            if trainer and hasattr(trainer, "strategy"):
+                trainer.strategy.teardown()
+            del callback
+            del trainer
+
     def test_thread_cleanup_on_exception(self, dummy_model, temp_log_dir):
         """Test that threads are cleaned up even when exceptions occur."""
         callback = EnvironmentDumpCallback(async_dump=True)


### PR DESCRIPTION
`threading.Thread` carries a `_thread.lock` (`_tstate_lock`) which is not picklable. When this callback is reachable from the trainer/module graph (e.g. via `pl_module.callbacks_modules`), spawn-mode DataLoader workers cannot serialise it and crash with:

    `TypeError: cannot pickle '_thread.lock' object`

Add a `__getstate__` that drops the thread handle on pickle. The dump thread is fire-and-forget on the main process; worker processes have no use for the handle.

Add a regression test 
Closes #416.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
