### PR TITLE
[BUG] fix two spawn-mode pickle bugs in Subset and DatasetMixin                                                                                                                  

### DIFF
--- a/stable_pretraining/data/datasets.py
+++ b/stable_pretraining/data/datasets.py
@@ -143,8 +143,14 @@ class Subset(Dataset):
         return len(self.indices)
 
     def __getattr__(self, name):
-        if name == "dataset":
-            raise AttributeError("dataset")
+        # Don't proxy dunders to the wrapped dataset. Pickle/copy/etc. on
+        # the Subset must use Subset's own machinery, not the inner ds's.
+        # On Python <3.11 ``object.__getstate__`` doesn't exist, so a bare
+        # proxy makes pickle read the inner dataset's ``__getstate__`` and
+        # serialize the wrong state (inner's ``__dict__`` under Subset's
+        # class), breaking spawn-mode DataLoader workers.
+        if name == "dataset" or (name.startswith("__") and name.endswith("__")):
+            raise AttributeError(name)
         return getattr(self.dataset, name)
 
 

--- a/stable_pretraining/data/datasets.py
+++ b/stable_pretraining/data/datasets.py
@@ -53,6 +53,18 @@ class DatasetMixin:
         """Attach a Lightning trainer so its state is injected into samples."""
         self._trainer = trainer
 
+    def __getstate__(self):
+        # Drop the trainer back-reference. Pickle-walking it reaches
+        # `trainer.train_dataloader._iterator`, a
+        # `_MultiProcessingDataLoaderIter`, which raises on __getstate__.
+        # Spawn-mode DataLoader workers therefore can't serialise any
+        # dataset that has had `set_pl_trainer` called on it.
+        # Workers see only a snapshot of trainer state at spawn time
+        # anyway; `process_sample` already handles `_trainer is None`.
+        state = self.__dict__.copy()
+        state["_trainer"] = None
+        return state
+
     def process_sample(self, sample, **kwargs):
         """Run a raw sample dict through trainer-injection and transforms.
 

--- a/stable_pretraining/tests/unit/test_datasets.py
+++ b/stable_pretraining/tests/unit/test_datasets.py
@@ -7,6 +7,31 @@ import pytest
 import torch
 from omegaconf import OmegaConf
 
+from stable_pretraining.data.datasets import Dataset
+
+
+class _InnerDatasetWithGetstate(Dataset):
+    """Module-level dataset used by the Subset pickle round-trip test.
+
+    Pickle requires classes to be resolvable by qualname, so this lives at
+    module scope. Defines its own ``__getstate__`` to mimic LanceDataset
+    / HDF5Dataset — the trigger for the Subset.__getattr__ proxy bug on
+    Python <3.11.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.color = "red"
+
+    def __getitem__(self, idx):
+        return {"x": idx}
+
+    def __len__(self):
+        return 5
+
+    def __getstate__(self):
+        return self.__dict__.copy()
+
 
 @pytest.mark.unit
 class TestDatasetUnit:
@@ -457,3 +482,30 @@ class TestDatasetUnit:
             _ = subset.dataset
         with pytest.raises(AttributeError):
             _ = subset.column_names
+
+    def test_subset_pickle_roundtrip_with_inner_getstate(self):
+        """Pickle round-trip works when the inner dataset defines ``__getstate__``.
+
+        Regression: on Python <3.11 ``object.__getstate__`` doesn't exist,
+        so attribute lookup for ``__getstate__`` fell through Subset's
+        ``__getattr__`` proxy to the inner dataset's ``__getstate__``.
+        Pickle then dumped the inner dataset's state under Subset's class.
+        Workers that unpickle the result observe a "Subset" with the
+        inner ds's ``__dict__`` and crash on first ``self.dataset`` access.
+
+        This bites real-world setups using LanceDataset (which forces
+        spawn-mode workers and defines ``__getstate__`` to drop a
+        non-picklable handle); HDF5Dataset hides the bug because its
+        workers fork.
+        """
+        import pickle
+
+        from stable_pretraining.data.datasets import Subset
+
+        subset = Subset(_InnerDatasetWithGetstate(), [0, 1, 2])
+        roundtripped = pickle.loads(pickle.dumps(subset))
+
+        assert roundtripped.dataset is not None
+        assert roundtripped.indices == [0, 1, 2]
+        assert roundtripped.dataset.color == "red"
+        assert len(roundtripped) == 3

--- a/stable_pretraining/tests/unit/test_datasets.py
+++ b/stable_pretraining/tests/unit/test_datasets.py
@@ -509,3 +509,37 @@ class TestDatasetUnit:
         assert roundtripped.indices == [0, 1, 2]
         assert roundtripped.dataset.color == "red"
         assert len(roundtripped) == 3
+
+    def test_dataset_mixin_drops_trainer_on_pickle(self):
+        """``DatasetMixin.__getstate__`` must drop ``_trainer``.
+
+        Regression: ``set_pl_trainer()`` stores ``self._trainer``, and
+        the trainer transitively reaches ``train_dataloader._iterator``
+        (a ``_MultiProcessingDataLoaderIter`` that raises
+        ``NotImplementedError`` on ``__getstate__``). Spawn-mode
+        DataLoader workers can therefore not pickle any dataset that
+        has had a trainer attached unless ``__getstate__`` drops the
+        back-reference.
+        """
+        from stable_pretraining.data.datasets import Dataset
+
+        class _FakeTrainer:
+            global_step = 0
+            current_epoch = 0
+
+        class _DS(Dataset):
+            def __getitem__(self, idx):
+                return {"x": idx}
+
+            def __len__(self):
+                return 3
+
+        ds = _DS()
+        ds.set_pl_trainer(_FakeTrainer())
+        assert ds._trainer is not None
+
+        state = ds.__getstate__()
+        assert state["_trainer"] is None
+
+        # Live attribute is preserved; only the pickled snapshot is None.
+        assert ds._trainer is not None


### PR DESCRIPTION

  Two related bugs surfacing under the same conditions: spawn-mode `DataLoader` workers + a wrapped dataset that's been hit by `set_pl_trainer` and/or has a non-trivial           
  `__getstate__`. Both bite real-world setups using `LanceDataset` (which forces spawn on Linux for fork-safety); HDF5 hides them because its workers fork.
                                                                                                                                                                                   
  Filing as a single PR since both live in the same module and were found in the same training run on `Python 3.10`

Tests:

 - test_subset_pickle_roundtrip_with_inner_getstate — wraps an inner dataset that defines its own __getstate__ (mimics LanceDataset / HDF5Dataset); asserts                       
  pickle.loads(pickle.dumps(subset)) preserves dataset, indices, and inner state.
  - test_dataset_mixin_drops_trainer_on_pickle — calls set_pl_trainer(), asserts __getstate__() returns a state with _trainer=None, asserts the live attribute is preserved (only  
  the pickled snapshot is cleared).        
           