### PR TITLE
fix(module): accept functools.partial as forward in spawn workers (#417)

### DIFF
--- a/stable_pretraining/module.py
+++ b/stable_pretraining/module.py
@@ -17,6 +17,22 @@ from stable_pretraining.callbacks.registry import log as _spt_log
 from stable_pretraining.callbacks.utils import log_header
 
 
+class _NamedForward:
+    """Adapter giving a callable ``__name__`` so spawn-mode workers can pickle it."""
+
+    __name__ = "forward"
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
+def _ensure_named_callable(fn):
+    return fn if hasattr(fn, "__name__") else _NamedForward(fn)
+
+
 @catch_errors_class()
 class Module(pl.LightningModule):
     """PyTorch Lightning module using manual optimization with multi-optimizer support.
@@ -136,7 +152,9 @@ class Module(pl.LightningModule):
             logging.warning(msg)
             raise ValueError(msg)
         else:
-            setattr(self, "forward", types.MethodType(forward, self))
+            setattr(
+                self, "forward", types.MethodType(_ensure_named_callable(forward), self)
+            )
 
         for key, value in kwargs.items():
             logging.info(f"  Setting attribute: self.{key} = {type(value)}")

--- a/stable_pretraining/tests/unit/test_module.py
+++ b/stable_pretraining/tests/unit/test_module.py
@@ -1,3 +1,6 @@
+import pickle
+from functools import partial
+
 import pytest
 from stable_pretraining import Module, forward
 from stable_pretraining.losses import NTXEntLoss
@@ -5,6 +8,20 @@ from stable_pretraining.data import DataModule
 import torch.nn as nn
 import torch
 from lightning.pytorch import Trainer
+
+
+def _partial_forward(self, batch, stage, cfg):
+    return {"loss": batch["image"].mean() * cfg["scale"]}
+
+
+@pytest.mark.unit
+def test_module_accepts_partial_forward():
+    module = Module(
+        backbone=nn.Linear(1, 1),
+        forward=partial(_partial_forward, cfg={"scale": 2.0}),
+        optim={"opt": {"modules": "backbone", "optimizer": {"type": "AdamW"}}},
+    )
+    pickle.dumps(module.forward)
 
 
 @pytest.mark.unit

--- a/stable_pretraining/tests/unit/test_slurm_index.py
+++ b/stable_pretraining/tests/unit/test_slurm_index.py
@@ -522,9 +522,10 @@ class TestEarlyPreemptFallback:
     def test_resolve_load_path_after_early_preempt_treats_as_fresh(
         self, tmp_path, monkeypatch
     ):
-        """After the early-preempt fallback, ``_resolve_load_path`` skips the
-        requeue last.ckpt requirement and returns the user's ckpt_path
-        (or None).
+        """After the early-preempt fallback, ``_resolve_load_path`` returns the user's ckpt_path.
+
+        Skips the requeue last.ckpt requirement and returns the user's
+        ckpt_path (or None).
         """
         from stable_pretraining.manager import Manager
         from stable_pretraining.tests.utils import (


### PR DESCRIPTION
addresses - https://github.com/galilai-group/stable-pretraining/issues/417
and also a pre-commit failure unrelated to this PR.

Module bound the user-supplied forward as types.MethodType(fn, self). multiprocessing's bound-method reducer reads __func__.__name__ to round-trip via getattr — callables without __name__ (notably partial) crashed spawn-mode DataLoader workers with AttributeError.

Wrap forward with _NamedForward when __name__ is missing. No effect on regular function forwards.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
