### PR TITLE
[Feature] Add PMSN as a method

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -41,6 +41,7 @@ Methods come in two forms:
 | MSN | — | `MSN` | — | — | [Assran et al., 2022](https://arxiv.org/abs/2204.07141) |
 | NEPA | — | `NEPA` | — | — | — |
 | PIRL | — | `PIRL` | — | — | [Misra & van der Maaten, 2020](https://arxiv.org/abs/1912.01991) |
+| PMSN | — | `PMSN` | — | — | [Assran et al., 2023](https://arxiv.org/abs/2210.07277) |
 | SALT | — | `SALT` | — | — | [Li et al., 2025](https://arxiv.org/pdf/2509.24317) |
 | SimMIM | — | `SimMIM` | — | — | [Xie et al., 2022](https://arxiv.org/abs/2111.09886) |
 | SimSiam | — | `SimSiam` | — | — | [Chen & He, 2021](https://arxiv.org/abs/2011.10566) |

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2,6 +2,15 @@
 Unreleased
 ----------
 
+**New method**
+
+- ``PMSN`` (Prior Matching for Siamese Networks): extends ``MSN`` by replacing
+  its uniform-prior mean-entropy regulariser with a KL-divergence term against
+  an arbitrary prior distribution over prototypes (power-law by default,
+  ``"uniform"``, or a custom tensor), per Assran et al., "The Hidden Uniform
+  Cluster Prior in Self-Supervised Learning" (ICLR 2023). Registered in
+  ``stable_pretraining.methods`` and ``METHODS.md``.
+
 **Discoverability improvements**
 
 - ``METHODS.md``: new root-level catalog table covering every method class and

--- a/stable_pretraining/methods/__init__.py
+++ b/stable_pretraining/methods/__init__.py
@@ -20,6 +20,7 @@ from .msn import MSN
 from .nepa import NEPA
 from .nnclr import NNCLR
 from .pirl import PIRL
+from .pmsn import PMSN
 from .salt import SALT
 from .simclr import SimCLR
 from .simmim import SimMIM
@@ -53,6 +54,7 @@ __all__ = [
     "NEPA",
     "NNCLR",
     "PIRL",
+    "PMSN",
     "SALT",
     "SimCLR",
     "SimMIM",

--- a/stable_pretraining/methods/pmsn.py
+++ b/stable_pretraining/methods/pmsn.py
@@ -1,0 +1,172 @@
+"""PMSN: Prior Matching for Siamese Networks.
+
+Extension of MSN that replaces the implicit uniform feature prior with an
+arbitrary (e.g. power-law) prior via KL-divergence regularisation, enabling
+better representation learning on class-imbalanced datasets.
+
+References:
+    Assran et al. "The Hidden Uniform Cluster Prior in Self-Supervised Learning."
+    ICLR 2023. https://arxiv.org/abs/2210.07277
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from stable_pretraining.methods.msn import MSN, MSNOutput
+
+
+@dataclass
+class PMSNOutput(MSNOutput):
+    """MSNOutput extended with a KL divergence term for logging."""
+
+    kl_loss: Optional[torch.Tensor] = None
+
+
+def power_law_prior(n_prototypes: int, tau: float, device=None) -> torch.Tensor:
+    """Compute a power-law prior: [π]_k ∝ 1 / k^τ  (1-indexed, L1-normalised).
+
+    Args:
+        n_prototypes: Number of prototypes K.
+        tau: Power-law exponent τ > 0.
+            τ=0 approaches uniform; larger τ yields a more long-tailed distribution.
+        device: Target device.
+
+    Returns:
+        (K,) tensor that sums to 1.
+    """
+    k = torch.arange(1, n_prototypes + 1, dtype=torch.float, device=device)
+    p = 1.0 / k.pow(tau)
+    return p / p.sum()
+
+
+def uniform_prior(n_prototypes: int, device=None) -> torch.Tensor:
+    """Uniform distribution over K prototypes."""
+    return torch.full((n_prototypes,), 1.0 / n_prototypes, device=device)
+
+
+class PMSN(MSN):
+    """PMSN: Prior Matching for Siamese Networks.
+
+    Identical architecture to MSN, with the loss replaced as follows:
+        MSN  : CE(student, teacher) + λ · H_mean_entropy  (uniform prior)
+        PMSN : CE(student, teacher) + λ · KL(p̄ ‖ π)      (arbitrary prior)
+
+    :param prior: "power_law" | "uniform" | (K,) tensor.
+        - "power_law" (default): uses pPL(τ), controlled by the tau argument.
+        - "uniform": equivalent to MSN (useful for ablation).
+        - Tensor: directly specify a custom prior (e.g. true class distribution of iNat18).
+    :param tau: Power-law exponent (only used when prior="power_law", default 0.25).
+    :param prior_weight: Weight λ for the KL term (default 1.0).
+    :param encoder_name: timm ViT name (default ``"vit_small_patch16_224"``).
+    :param projector_hidden_dim: Hidden dim (default 2048).
+    :param projector_bottleneck_dim: Bottleneck dim (default 256).
+    :param n_prototypes: Prototype count (default 1024).
+    :param mask_ratio: Patch mask ratio for the *student* (default 0.6).
+    :param temperature_student: Student softmax temperature (default 0.1).
+    :param temperature_teacher: Teacher softmax temperature (default 0.025).
+    :param ema_decay_start: Initial backbone/head EMA (default 0.996).
+    :param ema_decay_end: Final EMA (default 1.0).
+    :param image_size: Input size (default 224).
+    :param pretrained: Load pretrained timm weights.
+    """
+
+    def __init__(
+        self,
+        prior: Union[str, torch.Tensor] = "power_law",
+        tau: float = 0.25,
+        prior_weight: float = 1.0,
+        encoder_name: Union[str, nn.Module] = "vit_small_patch16_224",
+        projector_hidden_dim: int = 2048,
+        projector_bottleneck_dim: int = 256,
+        n_prototypes: int = 1024,
+        mask_ratio: float = 0.6,
+        temperature_student: float = 0.1,
+        temperature_teacher: float = 0.025,
+        ema_decay_start: float = 0.996,
+        ema_decay_end: float = 1.0,
+        image_size: int = 224,
+        pretrained: bool = False,
+    ):
+        super().__init__(
+            encoder_name=encoder_name,
+            projector_hidden_dim=projector_hidden_dim,
+            projector_bottleneck_dim=projector_bottleneck_dim,
+            n_prototypes=n_prototypes,
+            mask_ratio=mask_ratio,
+            temperature_student=temperature_student,
+            temperature_teacher=temperature_teacher,
+            me_max_weight=0.0,  # Disable MSN's me_max; replaced by PMSN's KL term
+            ema_decay_start=ema_decay_start,
+            ema_decay_end=ema_decay_end,
+            image_size=image_size,
+            pretrained=pretrained,
+        )
+
+        self.prior_type = prior if isinstance(prior, str) else "custom"
+        self.tau = tau
+        self.prior_weight = prior_weight
+        self.n_prototypes = n_prototypes
+
+        # Register prior as a buffer so .to(device) and state_dict are handled automatically
+        if isinstance(prior, torch.Tensor):
+            assert prior.shape == (n_prototypes,), (
+                f"prior tensor must be shape ({n_prototypes},), got {tuple(prior.shape)}"
+            )
+            self.register_buffer("_prior", prior / prior.sum())
+        elif prior == "uniform":
+            self.register_buffer("_prior", uniform_prior(n_prototypes))
+        elif prior == "power_law":
+            self.register_buffer("_prior", power_law_prior(n_prototypes, tau))
+        else:
+            raise ValueError(
+                f"Unknown prior type: {prior!r}. Use 'power_law', 'uniform', or a Tensor."
+            )
+
+    def _prior_kl(self, student_logits: torch.Tensor) -> torch.Tensor:
+        """Compute KL(p̄ ‖ π).
+
+        p̄ = mean_i softmax(s_logits_i / T_student)
+        KL(p̄ ‖ π) = Σ_k p̄_k log(p̄_k / π_k)
+        """
+        mean_p = F.softmax(student_logits / self.temperature_student, dim=-1).mean(
+            dim=0
+        )
+        mean_p = mean_p.clamp(min=1e-8)
+        prior = self._prior.clamp(min=1e-8)
+        return (mean_p * (mean_p.log() - prior.log())).sum()
+
+    def forward(
+        self,
+        view1: Optional[torch.Tensor] = None,
+        view2: Optional[torch.Tensor] = None,
+        images: Optional[torch.Tensor] = None,
+    ) -> PMSNOutput:
+        # Eval / single-image: delegate to parent
+        if images is not None or (view1 is not None and view2 is None):
+            out = super().forward(view1=view1, view2=view2, images=images)
+            return PMSNOutput(
+                loss=out.loss,
+                embedding=out.embedding,
+                student_logits=out.student_logits,
+                teacher_logits=out.teacher_logits,
+                kl_loss=None,
+            )
+
+        # Training: parent forward gives CE-only loss (me_max_weight=0)
+        parent_out = super().forward(view1=view1, view2=view2)
+
+        # Add KL(p̄ ‖ π) regularisation term
+        kl = self._prior_kl(parent_out.student_logits)
+        loss = parent_out.loss + self.prior_weight * kl
+
+        return PMSNOutput(
+            loss=loss,
+            embedding=parent_out.embedding,
+            student_logits=parent_out.student_logits,
+            teacher_logits=parent_out.teacher_logits,
+            kl_loss=kl.detach(),
+        )

--- a/stable_pretraining/tests/unit/test_methods_smoke.py
+++ b/stable_pretraining/tests/unit/test_methods_smoke.py
@@ -160,6 +160,18 @@ def test_msn_forward_backward():
     _assert_loss_and_backward(model, output)
 
 
+def test_pmsn_forward_backward():
+    model = M.PMSN(
+        encoder_name=TINY_VIT,
+        n_prototypes=256,
+        mask_ratio=0.5,
+    )
+    model.train()
+    v1, v2 = _two_views()
+    output = model(view1=v1, view2=v2)
+    _assert_loss_and_backward(model, output)
+
+
 def test_swav_forward_backward_two_view():
     """SwAV's compatibility 2-view forward (no multi-crop)."""
     model = M.SwAV(

--- a/stable_pretraining/tests/unit/test_pmsn.py
+++ b/stable_pretraining/tests/unit/test_pmsn.py
@@ -1,0 +1,170 @@
+"""Unit tests for PMSN (Prior Matching for Siamese Networks)."""
+
+from typing import Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from stable_pretraining.methods.msn import MSN
+from stable_pretraining.methods.pmsn import PMSN, power_law_prior, uniform_prior
+
+pytestmark = pytest.mark.unit
+
+TINY_VIT = "vit_tiny_patch16_224"
+B = 2
+C, H, W = 3, 224, 224
+
+SMALL_KWARGS = dict(
+    encoder_name=TINY_VIT,
+    n_prototypes=32,
+    projector_hidden_dim=64,
+    projector_bottleneck_dim=16,
+    mask_ratio=0.5,
+)
+
+
+def _two_views() -> Tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(0)
+    return (
+        torch.randn(B, C, H, W, generator=g),
+        torch.randn(B, C, H, W, generator=g),
+    )
+
+
+# --- prior helper functions -----------------------------------------------
+
+
+def test_power_law_prior_sums_to_one_and_is_decreasing():
+    prior = power_law_prior(16, tau=0.25)
+    assert prior.shape == (16,)
+    assert torch.allclose(prior.sum(), torch.tensor(1.0), atol=1e-6)
+    assert torch.all(prior[:-1] >= prior[1:])
+
+
+def test_power_law_prior_tau_zero_is_uniform():
+    prior = power_law_prior(16, tau=0.0)
+    assert torch.allclose(prior, uniform_prior(16), atol=1e-6)
+
+
+def test_uniform_prior_is_flat_and_normalised():
+    prior = uniform_prior(8)
+    assert prior.shape == (8,)
+    assert torch.allclose(prior, torch.full((8,), 1.0 / 8))
+    assert torch.allclose(prior.sum(), torch.tensor(1.0))
+
+
+# --- prior registration on the module --------------------------------------
+
+
+def test_pmsn_default_prior_is_power_law():
+    model = PMSN(**SMALL_KWARGS, tau=0.5)
+    expected = power_law_prior(32, tau=0.5)
+    assert torch.allclose(model._prior, expected, atol=1e-6)
+
+
+def test_pmsn_uniform_prior_option():
+    model = PMSN(**SMALL_KWARGS, prior="uniform")
+    assert torch.allclose(model._prior, uniform_prior(32), atol=1e-6)
+
+
+def test_pmsn_custom_prior_tensor_is_normalised():
+    raw = torch.arange(1, 33, dtype=torch.float)
+    model = PMSN(**SMALL_KWARGS, prior=raw)
+    assert torch.allclose(model._prior, raw / raw.sum(), atol=1e-6)
+    assert model.prior_type == "custom"
+
+
+def test_pmsn_custom_prior_wrong_shape_raises():
+    bad = torch.ones(10)
+    with pytest.raises(AssertionError, match="prior tensor must be shape"):
+        PMSN(**SMALL_KWARGS, prior=bad)
+
+
+def test_pmsn_unknown_prior_string_raises():
+    with pytest.raises(ValueError, match="Unknown prior type"):
+        PMSN(**SMALL_KWARGS, prior="not_a_real_prior")
+
+
+# --- forward / backward -----------------------------------------------------
+
+
+def test_pmsn_forward_backward():
+    model = PMSN(**SMALL_KWARGS)
+    model.train()
+    v1, v2 = _two_views()
+    output = model(view1=v1, view2=v2)
+
+    assert output.loss.ndim == 0
+    assert torch.isfinite(output.loss)
+    assert output.kl_loss is not None
+    assert torch.isfinite(output.kl_loss)
+
+    output.loss.backward()
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "no parameter received a gradient"
+    assert any(g.abs().sum() > 0 for g in grads)
+
+
+def test_pmsn_kl_loss_matches_manual_computation():
+    torch.manual_seed(0)
+    model = PMSN(**SMALL_KWARGS)
+    model.train()
+    v1, v2 = _two_views()
+    output = model(view1=v1, view2=v2)
+
+    mean_p = F.softmax(output.student_logits / model.temperature_student, dim=-1).mean(
+        dim=0
+    )
+    mean_p = mean_p.clamp(min=1e-8)
+    prior = model._prior.clamp(min=1e-8)
+    expected_kl = (mean_p * (mean_p.log() - prior.log())).sum()
+
+    assert torch.allclose(output.kl_loss, expected_kl, atol=1e-6)
+
+
+def test_pmsn_prior_weight_zero_matches_parent_msn_ce():
+    """With prior_weight=0, PMSN's loss must reduce to MSN's CE-only loss.
+
+    PMSN disables MSN's own me_max term (me_max_weight=0.0) and adds
+    prior_weight * KL instead, so zeroing prior_weight should reproduce
+    the parent's CE-only forward exactly given the same random mask.
+    """
+    model = PMSN(**SMALL_KWARGS, prior_weight=0.0)
+    model.train()
+    v1, v2 = _two_views()
+
+    torch.manual_seed(42)
+    pmsn_out = model(view1=v1, view2=v2)
+
+    torch.manual_seed(42)
+    msn_out = MSN.forward(model, view1=v1, view2=v2)
+
+    assert torch.allclose(pmsn_out.loss, msn_out.loss, atol=1e-6)
+
+
+def test_pmsn_prior_weight_scales_kl_contribution():
+    model = PMSN(**SMALL_KWARGS, prior_weight=2.0)
+    model.train()
+    v1, v2 = _two_views()
+
+    torch.manual_seed(7)
+    out = model(view1=v1, view2=v2)
+
+    torch.manual_seed(7)
+    parent_out = MSN.forward(model, view1=v1, view2=v2)
+
+    assert torch.allclose(out.loss, parent_out.loss + 2.0 * out.kl_loss, atol=1e-6)
+
+
+def test_pmsn_eval_mode_delegates_to_parent_without_kl():
+    model = PMSN(**SMALL_KWARGS)
+    model.eval()
+    v1, _ = _two_views()
+
+    with torch.no_grad():
+        output = model(images=v1)
+
+    assert output.kl_loss is None
+    assert torch.isfinite(output.loss)
+    assert output.embedding is not None and output.embedding.shape[0] == B


### PR DESCRIPTION
## Description

Adds **PMSN** (Prior Matching for Siamese Networks) as a new SSL method class.

PMSN extends `MSN` by replacing its implicit uniform-cluster-prior mean-entropy
regularizer with a KL-divergence term against an arbitrary prior distribution
over prototypes:

- `MSN`  : `CE(student, teacher) + λ · H_mean_entropy` (implicit uniform prior)
- `PMSN` : `CE(student, teacher) + λ · KL(p̄ ‖ π)` (arbitrary prior `π`)

`π` can be `"power_law"` (default, `τ=0.25` matching the paper), `"uniform"`
(equivalent to MSN, useful for ablation), or a custom tensor (e.g. the true
class distribution of a long-tailed dataset like iNat18).

Reference: Assran et al., *"The Hidden Uniform Cluster Prior in Self-Supervised
Learning"*, ICLR 2023 ([arXiv:2210.07277](https://arxiv.org/abs/2210.07277)).

Changes:
- `stable_pretraining/methods/pmsn.py` — new `PMSN` method class + `power_law_prior`/`uniform_prior` helpers
- `stable_pretraining/methods/__init__.py` — export `PMSN`
- `METHODS.md` — catalog row for `PMSN`
- `RELEASES.rst` — changelog entry
- `stable_pretraining/tests/unit/test_pmsn.py` — unit tests for prior helpers, prior registration/validation, forward/backward, and equivalence to MSN's CE-only loss at `prior_weight=0`
- `stable_pretraining/tests/unit/test_methods_smoke.py` — added `PMSN` to the per-method forward/backward smoke sweep

## Checklist

- [x] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.