### PR TITLE
[BugFix] Concat views before shared projector pass in _embed_views

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --user --upgrade --progress-bar off pip
+      - name: Pin CI dependencies
+        run: |
+          python -m pip install --user -r requirements-ci.txt
       - name: Install 'stable_pretraining' package
         run: |
           python -m pip install --user -e .[dev,trackio,swanlab]

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,9 +7,23 @@ Tests in stable-pretraining are categorized to separate fast unit tests from slo
 
 - **Unit Tests** (`@pytest.mark.unit`): Fast, no GPU, no downloads
 - **Integration Tests** (`@pytest.mark.integration`): Full training runs
+- **Regression Tests** (`@pytest.mark.regression`): One seeded epoch per method on fake data
 - **GPU Tests** (`@pytest.mark.gpu`): Require CUDA
 - **Slow Tests** (`@pytest.mark.slow`): Take > 1 minute
 - **Download Tests** (`@pytest.mark.download`): Download data
+
+## Local Environment
+
+The integration and regression jobs both install `requirements-ci.txt` before
+the package, so a local checkout needs the same versions to reproduce what CI
+sees. `.venv/` is gitignored; every dev box keeps one at the repo root:
+
+```bash
+uv venv --python 3.12 .venv
+uv pip install --python .venv/bin/python -r requirements-ci.txt
+uv pip install --python .venv/bin/python -e ".[dev]"
+source .venv/bin/activate
+```
 
 ## Running Tests
 
@@ -19,6 +33,9 @@ python -m pytest -m unit
 
 # Integration tests
 python -m pytest -m integration
+
+# Regression tests
+python -m pytest stable_pretraining/tests/ -m regression
 
 # All tests
 python -m pytest

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,12 +1,18 @@
-# Pin key packages for deterministic integration tests.
+# Pin key packages for deterministic integration and regression tests.
 # These versions must match the local dev environment so that
 # seeded loss values stay consistent across CI and local runs.
-torch==2.11.0
-torchvision==0.26.0
-numpy==2.4.4
-timm==1.0.26
-transformers==5.4.0
-lightning==2.6.1
+#
+# The reference losses in stable_pretraining/tests/regression/test_methods.py
+# are captured against exactly this stack. Both the integration job and the
+# regression job install this file before installing the package, so a change
+# in the pinned versions shows up as a dependency diff rather than as a
+# mysterious drift failure.
+torch==2.13.0
+torchvision==0.28.0
+numpy==2.5.1
+timm==1.0.28
+transformers==5.14.1
+lightning==2.6.5
 # datasets>=2.20 is required for pyarrow>=21 (older datasets imported the removed
 # pyarrow.PyExtensionType). Pinned-floor so CI's --user install upgrades any
 # stale datasets; see pyproject for the full rationale.

--- a/stable_pretraining/forward.py
+++ b/stable_pretraining/forward.py
@@ -114,6 +114,27 @@ def _get_views_by_prefix(
     return global_views, local_views, all_views
 
 
+def _embed_views(views: list, backbone, projector):
+    """Run each view through ``backbone`` and then ``projector``.
+
+    Shared by the joint-embedding forwards so they all agree on how a list of
+    views is turned into embeddings and projections.
+
+    Args:
+        views: List of view dicts, each holding an ``"image"`` tensor.
+        backbone: Callable mapping a batch of images to embeddings.
+        projector: Callable mapping embeddings to projections.
+
+    Returns:
+        Tuple ``(embeddings, projections)``, each a list with one entry per
+        view, in the order the views were given.
+    """
+    embeddings = [backbone(view["image"]) for view in views]
+    projections = [projector(embedding) for embedding in embeddings]
+    return embeddings, projections
+
+
+
 def supervised(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
     """Forward function for standard supervised training.
 
@@ -230,7 +251,7 @@ def simclr(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
                 "For other configurations, please implement a custom forward function."
             )
 
-        embeddings = [self.backbone(view["image"]) for view in views]
+        embeddings, projections = _embed_views(views, self.backbone, self.projector)
         out["embedding"] = torch.cat(embeddings, dim=0)
 
         # Concatenate labels for callbacks (probes need this)
@@ -238,7 +259,6 @@ def simclr(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
             out["label"] = torch.cat([view["label"] for view in views], dim=0)
 
         if self.training:
-            projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.simclr_loss(projections[0], projections[1])
             self.log(
                 f"{stage}/loss",
@@ -318,9 +338,6 @@ def byol(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
         if "label" in views[0]:
             out["label"] = torch.cat([view["label"] for view in views], dim=0)
 
-        # Get online embeddings for both views
-        online_features = [self.backbone.forward_student(img) for img in images]
-
         # Return early if not training
         if not self.training:
             with torch.no_grad():
@@ -329,15 +346,16 @@ def byol(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
             return {"embedding": target_only_features.detach(), **out}
 
         # Process online network
-        online_proj = [self.projector.forward_student(feat) for feat in online_features]
+        online_features, online_proj = _embed_views(
+            views, self.backbone.forward_student, self.projector.forward_student
+        )
         online_pred = [self.predictor(proj) for proj in online_proj]
 
         # Process target network
         with torch.no_grad():
-            target_features = [self.backbone.forward_teacher(img) for img in images]
-            target_proj = [
-                self.projector.forward_teacher(feat) for feat in target_features
-            ]
+            target_features, target_proj = _embed_views(
+                views, self.backbone.forward_teacher, self.projector.forward_teacher
+            )
 
         if not hasattr(self, "byol_loss"):
             raise ValueError(
@@ -429,7 +447,7 @@ def vicreg(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
                 "For other configurations, please implement a custom forward function."
             )
 
-        embeddings = [self.backbone(view["image"]) for view in views]
+        embeddings, projections = _embed_views(views, self.backbone, self.projector)
         out["embedding"] = torch.cat(embeddings, dim=0)
 
         # Concatenate labels for callbacks
@@ -437,7 +455,6 @@ def vicreg(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:
             out["label"] = torch.cat([view["label"] for view in views], dim=0)
 
         if self.training:
-            projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.vicreg_loss(projections[0], projections[1])
             self.log(
                 f"{stage}/loss",
@@ -507,7 +524,7 @@ def barlow_twins(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Ten
                 "For other configurations, please implement a custom forward function."
             )
 
-        embeddings = [self.backbone(view["image"]) for view in views]
+        embeddings, projections = _embed_views(views, self.backbone, self.projector)
         out["embedding"] = torch.cat(embeddings, dim=0)
 
         # Concatenate labels for callbacks
@@ -515,7 +532,6 @@ def barlow_twins(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Ten
             out["label"] = torch.cat([view["label"] for view in views], dim=0)
 
         if self.training:
-            projections = [self.projector(emb) for emb in embeddings]
             out["loss"] = self.barlow_loss(projections[0], projections[1])
             self.log(
                 f"{stage}/loss",

--- a/stable_pretraining/forward.py
+++ b/stable_pretraining/forward.py
@@ -115,13 +115,20 @@ def _get_views_by_prefix(
 
 
 def _embed_views(views: list, backbone, projector):
-    """Run each view through ``backbone`` and then ``projector``.
+    """Run all views through ``backbone`` and ``projector`` as a single batch.
+
+    The views are concatenated along the batch dimension before the forward
+    pass so that normalization layers (e.g. ``BatchNorm`` in the projector)
+    compute statistics over the full multi-view batch instead of per view.
+    This matches the reference implementations of SimCLR, VICReg, and Barlow
+    Twins, which all concatenate views prior to the shared projector pass.
 
     Shared by the joint-embedding forwards so they all agree on how a list of
     views is turned into embeddings and projections.
 
     Args:
-        views: List of view dicts, each holding an ``"image"`` tensor.
+        views: List of view dicts, each holding an ``"image"`` tensor. All
+            images are expected to share the same shape after batching.
         backbone: Callable mapping a batch of images to embeddings.
         projector: Callable mapping embeddings to projections.
 
@@ -129,10 +136,13 @@ def _embed_views(views: list, backbone, projector):
         Tuple ``(embeddings, projections)``, each a list with one entry per
         view, in the order the views were given.
     """
-    embeddings = [backbone(view["image"]) for view in views]
-    projections = [projector(embedding) for embedding in embeddings]
+    batch_sizes = [view["image"].shape[0] for view in views]
+    images = torch.cat([view["image"] for view in views], dim=0)
+    all_embeddings = backbone(images)
+    all_projections = projector(all_embeddings)
+    embeddings = list(all_embeddings.split(batch_sizes, dim=0))
+    projections = list(all_projections.split(batch_sizes, dim=0))
     return embeddings, projections
-
 
 
 def supervised(self, batch: dict[str, Any], stage: str) -> dict[str, torch.Tensor]:

--- a/stable_pretraining/tests/regression/test_methods.py
+++ b/stable_pretraining/tests/regression/test_methods.py
@@ -222,14 +222,16 @@ METHOD_BUILDERS = {
     "supervised": build_supervised,
 }
 
-# Reference loss values captured on 2026-04-09 with seed=42.
+# Reference loss values captured on 2026-07-21 with seed=42, against the
+# dependency versions pinned in requirements-ci.txt (both the regression and
+# the integration CI jobs install that file, so CI and a local dev env agree).
 # If any method's loss changes, the forward/loss logic has drifted.
 # Re-capture with: python stable_pretraining/tests/regression/_capture_refs.py
 REFERENCE_LOSSES = {
-    "simclr": ("fit/loss_epoch", 1.645321011543274),
-    "byol": ("fit/loss_epoch", 1.822302222251892),
+    "simclr": ("fit/loss_epoch", 1.6453218460083008),
+    "byol": ("fit/loss_epoch", 1.8223044872283936),
     "vicreg": ("fit/loss_epoch", 18.119741439819336),
-    "barlow_twins": ("fit/loss_epoch", 1.7105509042739868),
+    "barlow_twins": ("fit/loss_epoch", 1.7105531692504883),
     "supervised": ("validate/loss_step", 2.3338754177093506),
 }
 

--- a/stable_pretraining/tests/regression/test_methods.py
+++ b/stable_pretraining/tests/regression/test_methods.py
@@ -222,16 +222,20 @@ METHOD_BUILDERS = {
     "supervised": build_supervised,
 }
 
-# Reference loss values captured on 2026-07-21 with seed=42, against the
+# Reference loss values captured on 2026-08-03 with seed=42, against the
 # dependency versions pinned in requirements-ci.txt (both the regression and
 # the integration CI jobs install that file, so CI and a local dev env agree).
+# The joint-embedding refs (simclr, byol, vicreg, barlow_twins) were re-captured
+# after _embed_views was switched to concatenate views before the shared
+# backbone/projector pass, which changes projector BatchNorm statistics; the
+# supervised ref was unaffected and matches the previous capture exactly.
 # If any method's loss changes, the forward/loss logic has drifted.
 # Re-capture with: python stable_pretraining/tests/regression/_capture_refs.py
 REFERENCE_LOSSES = {
-    "simclr": ("fit/loss_epoch", 1.6453218460083008),
-    "byol": ("fit/loss_epoch", 1.8223044872283936),
-    "vicreg": ("fit/loss_epoch", 18.119741439819336),
-    "barlow_twins": ("fit/loss_epoch", 1.7105531692504883),
+    "simclr": ("fit/loss_epoch", 1.6480257511138916),
+    "byol": ("fit/loss_epoch", 1.8251674175262451),
+    "vicreg": ("fit/loss_epoch", 18.135976791381836),
+    "barlow_twins": ("fit/loss_epoch", 1.74131441116333),
     "supervised": ("validate/loss_step", 2.3338754177093506),
 }
 


### PR DESCRIPTION
## Summary

- The joint-embedding forwards (SimCLR, BYOL, VICReg, Barlow Twins) all route through `_embed_views`, which used to run the backbone and projector independently per view. That meant any `BatchNorm` in the projector saw a single view's statistics at a time — but every reference implementation (SimCLR, VICReg, Barlow Twins) concatenates the views into one batch before that pass.
- This PR changes `_embed_views` to concatenate views → single `backbone(images)` → single `projector(embeddings)` → split back into per-view lists, so projector BN normalizes over the full multi-view batch like the references.
- Re-captured the seeded regression references for the four joint-embedding methods (BN stats change with the new batching); `supervised` did not need re-capture and stayed bit-identical, confirming no other forwards were affected.

## Test plan

- [x] `pytest stable_pretraining/tests/unit/test_forward_functions.py` — 13/13 pass
- [x] `pytest -m regression` — 10/10 pass with the refreshed refs
- [x] `pytest -m unit` — the four previously-failing `test_method_matches_reference[*]` cases now pass; the 14 remaining unit failures (`test_dino_visualizers`, `test_hardware_monitor`, `test_trackio`) reproduce identically on the pre-change tree, so they are pre-existing and unrelated to this change
- [x] `ruff check` + `ruff format --check` clean on the two edited files